### PR TITLE
Add industry presets and broaden preset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Local-first • Zero dependencies • 10-20ms latency • 100% offline • 571+ 
 - **Enterprise SaaS Ready** - Multi-tenancy, persistent audit logging, webhooks, REST API (NEW 🚀)
 - **Production Monitoring** - Prometheus metrics, Grafana dashboards, health checks (NEW 🚀)
 - **Context-Aware** - 90%+ accuracy with false positive reduction
-- **Compliance Ready** - GDPR, HIPAA, CCPA, FERPA presets
+- **Compliance Ready** - GDPR, HIPAA, CCPA plus finance, education, healthcare, and transport/logistics presets
 - **100% Local** - Your data never leaves your infrastructure
 - **Zero Dependencies** - ~100KB bundle, works everywhere (structured data built-in)
 - **Document Processing** - PDF, DOCX, TXT, JSON, CSV, XLSX, images (OCR)
@@ -1856,8 +1856,9 @@ openredaction detect "Email john@example.com"
 # Scan and show severity breakdown
 openredaction scan "Contact john@example.com or call 555-123-4567"
 
-# Use compliance preset
+# Use compliance/industry preset
 openredaction detect "SSN: 123-45-6789" --preset hipaa
+openredaction detect "BIC: DEUTDEFF" --preset finance
 
 # JSON output
 openredaction detect "Card: 4532015112830366" --json
@@ -1996,6 +1997,11 @@ const redactor = await OpenRedaction.fromConfig();
 - `openredaction:gdpr` - GDPR compliance preset
 - `openredaction:hipaa` - HIPAA compliance preset
 - `openredaction:ccpa` - CCPA compliance preset
+- `openredaction:finance` - Financial services (SWIFT/BIC, accounts, trading, payments)
+- `openredaction:education` - Education/FERPA (student IDs, transcripts, faculty IDs)
+- `openredaction:healthcare` - Provider operations (MRNs, claims, NPI/license IDs)
+- `openredaction:healthcare-research` - Clinical research (trial IDs, protocols, genetic markers)
+- `openredaction:transport-logistics` - Fleet, shipping, and tracking identifiers
 
 ### Integration with Disclosurely
 
@@ -2225,12 +2231,12 @@ const shield = new OpenRedaction({
   // Deterministic placeholders
   deterministic: true,       // Default: true
 
-  // Compliance preset
-  preset: 'gdpr' // or 'hipaa', 'ccpa'
+  // Compliance/industry preset
+  preset: 'gdpr' // or 'hipaa', 'ccpa', 'finance', 'education', 'healthcare', 'transport-logistics'
 });
 ```
 
-## Compliance Presets
+## Compliance & Industry Presets
 
 ### GDPR (European Union)
 ```typescript
@@ -2249,6 +2255,36 @@ Detects: Email, names, SSN, US phones, addresses, dates of birth, medical IDs
 const shield = new OpenRedaction({ preset: 'ccpa' });
 ```
 Detects: Email, names, SSN, US phones, addresses, IP addresses, usernames
+
+### Finance (Banking & Payments)
+```typescript
+const shield = new OpenRedaction({ preset: 'finance' });
+```
+Detects: SWIFT/BIC, IBAN, routing/sort codes, credit cards, trading and loan accounts
+
+### Education (Schools & Universities)
+```typescript
+const shield = new OpenRedaction({ preset: 'education' });
+```
+Detects: Student IDs, transcripts, faculty IDs, course codes, enrollment and aid references
+
+### Healthcare Operations
+```typescript
+const shield = new OpenRedaction({ preset: 'healthcare' });
+```
+Detects: Medical record numbers, patient IDs, claims, NPI/license IDs, lab and device references
+
+### Healthcare Research & Clinical Trials
+```typescript
+const shield = new OpenRedaction({ preset: 'healthcare-research' });
+```
+Detects: Trial participant IDs, protocol numbers, ICD-10/CPT codes, genetic markers, biobank samples
+
+### Transportation & Logistics
+```typescript
+const shield = new OpenRedaction({ preset: 'transport-logistics' });
+```
+Detects: VINs, license plates, fleet/driver IDs, shipment tracking, airway bills, container numbers
 
 ## Advanced Usage
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -33,7 +33,7 @@ Full documentation available at [GitHub](https://github.com/sam247/openredaction
 - 🧠 **Semantic Detection** - Hybrid NER + regex with 40+ contextual rules
 - 🎨 **Multiple Redaction Modes** - Placeholder, mask-middle, mask-all, format-preserving, token-replace
 - ✅ **Built-in Validators** - Luhn, IBAN, NHS, National ID checksums
-- 🔒 **Compliance Presets** - GDPR, HIPAA, CCPA, PCI-DSS
+- 🔒 **Compliance Presets** - GDPR, HIPAA, CCPA plus finance, education, healthcare, and transport presets
 - 🎭 **Deterministic Placeholders** - Consistent redaction for same values
 - 🌍 **Global Coverage** - 50+ countries
 - 📄 **Structured Data Support** - JSON, CSV, XLSX with path/cell tracking

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -19,7 +19,7 @@ Usage:
   openredaction --help                     Show this help message
 
 Detection Options:
-  --preset <name>                       Use compliance preset (gdpr, hipaa, ccpa)
+  --preset <name>                       Use compliance/industry preset (gdpr, hipaa, ccpa, finance, education, healthcare, transport-logistics)
   --patterns <types>                    Comma-separated list of pattern types to use
   --no-names                            Exclude name detection
   --no-emails                           Exclude email detection
@@ -34,6 +34,7 @@ Feedback Options:
 Examples:
   openredaction detect "Email john@example.com"
   openredaction detect "SSN: 123-45-6789" --preset hipaa
+  openredaction detect "Routing SWIFT: DEUTDEFF" --preset finance
   openredaction scan "Contact john@example.com or call 555-123-4567"
   openredaction feedback false-positive "API" --type NAME --context "Call the API"
   openredaction stats

--- a/packages/core/src/config/ConfigLoader.ts
+++ b/packages/core/src/config/ConfigLoader.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { OpenRedactionOptions } from '../types.js';
+import { OpenRedactionOptions, PresetName } from '../types.js';
 
 export interface OpenRedactionConfig extends OpenRedactionOptions {
   extends?: string | string[];
@@ -140,9 +140,24 @@ export class ConfigLoader {
 
     // Handle compliance presets
     if (preset.startsWith('openredaction:')) {
-      const complianceType = preset.replace('openredaction:', '') as 'gdpr' | 'hipaa' | 'ccpa';
-      if (['gdpr', 'hipaa', 'ccpa'].includes(complianceType)) {
-        return { preset: complianceType };
+      const presetName = preset.replace('openredaction:', '') as PresetName;
+      const supportedPresets: PresetName[] = [
+        'gdpr',
+        'hipaa',
+        'ccpa',
+        'healthcare',
+        'healthcare-provider',
+        'healthcare-research',
+        'finance',
+        'financial-services',
+        'education',
+        'transport-logistics',
+        'transportation',
+        'logistics'
+      ];
+
+      if (supportedPresets.includes(presetName)) {
+        return { preset: presetName };
       }
     }
 
@@ -160,7 +175,8 @@ export class ConfigLoader {
 export default {
   // Extend built-in presets
   // Options: 'openredaction:recommended', 'openredaction:strict', 'openredaction:minimal'
-  // Or compliance: 'openredaction:gdpr', 'openredaction:hipaa', 'openredaction:ccpa'
+  // Or compliance/industry presets: 'openredaction:gdpr', 'openredaction:hipaa', 'openredaction:ccpa',
+  // 'openredaction:finance', 'openredaction:education', 'openredaction:healthcare', 'openredaction:transport-logistics'
   extends: ['openredaction:recommended'],
 
   // Detection options

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export type {
   PIIMatch,
   DetectionResult,
   OpenRedactionOptions,
+  PresetName,
   RedactionMode,
   Validator,
   IAuditLogger,
@@ -123,7 +124,17 @@ export {
   validateEmail
 } from './validators';
 
-export { gdprPreset, hipaaPreset, ccpaPreset, getPreset } from './utils/presets';
+export {
+  gdprPreset,
+  hipaaPreset,
+  ccpaPreset,
+  healthcarePreset,
+  healthcareResearchPreset,
+  financePreset,
+  educationPreset,
+  transportLogisticsPreset,
+  getPreset
+} from './utils/presets';
 
 // Local learning system
 export { LocalLearningStore } from './learning/LocalLearningStore';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -95,6 +95,20 @@ export type RedactionMode =
 /**
  * Configuration options for OpenRedaction
  */
+export type PresetName =
+  | 'gdpr'
+  | 'hipaa'
+  | 'ccpa'
+  | 'healthcare'
+  | 'healthcare-provider'
+  | 'healthcare-research'
+  | 'finance'
+  | 'financial-services'
+  | 'education'
+  | 'transport-logistics'
+  | 'transportation'
+  | 'logistics';
+
 export interface OpenRedactionOptions {
   /** Include name detection (default: true) */
   includeNames?: boolean;
@@ -104,6 +118,8 @@ export interface OpenRedactionOptions {
   includePhones?: boolean;
   /** Include email detection (default: true) */
   includeEmails?: boolean;
+  /** Pattern categories to include (e.g., ['personal', 'financial']) */
+  categories?: string[];
   /** Whitelist specific patterns only */
   patterns?: string[];
   /** Add custom patterns */
@@ -115,7 +131,7 @@ export interface OpenRedactionOptions {
   /** Redaction mode (default: 'placeholder') */
   redactionMode?: RedactionMode;
   /** Compliance preset */
-  preset?: 'gdpr' | 'hipaa' | 'ccpa';
+  preset?: PresetName;
   /** Enable context-aware detection (default: true) */
   enableContextAnalysis?: boolean;
   /** Minimum confidence threshold for detections (0-1, default: 0.5) */

--- a/packages/core/src/utils/presets.ts
+++ b/packages/core/src/utils/presets.ts
@@ -2,7 +2,7 @@
  * Compliance preset configurations
  */
 
-import { OpenRedactionOptions } from '../types';
+import { OpenRedactionOptions, PresetName } from '../types';
 
 /**
  * GDPR compliance preset - European Union data protection
@@ -82,16 +82,87 @@ export const ccpaPreset: Partial<OpenRedactionOptions> = {
 };
 
 /**
+ * Healthcare operations preset - provider-centric coverage
+ */
+export const healthcarePreset: Partial<OpenRedactionOptions> = {
+  includeNames: true,
+  includeEmails: true,
+  includePhones: true,
+  includeAddresses: true,
+  categories: ['personal', 'contact', 'healthcare', 'insurance', 'government']
+};
+
+/**
+ * Healthcare research preset - clinical research and trials
+ */
+export const healthcareResearchPreset: Partial<OpenRedactionOptions> = {
+  includeNames: true,
+  includeEmails: true,
+  includePhones: true,
+  includeAddresses: true,
+  categories: ['personal', 'contact', 'healthcare', 'insurance', 'government']
+};
+
+/**
+ * Financial services preset - banking, trading, and payments
+ */
+export const financePreset: Partial<OpenRedactionOptions> = {
+  includeNames: true,
+  includeEmails: true,
+  includePhones: true,
+  includeAddresses: true,
+  categories: ['personal', 'contact', 'financial', 'government', 'network']
+};
+
+/**
+ * Education preset - FERPA-style coverage for schools and universities
+ */
+export const educationPreset: Partial<OpenRedactionOptions> = {
+  includeNames: true,
+  includeEmails: true,
+  includePhones: true,
+  includeAddresses: true,
+  categories: ['personal', 'contact', 'education', 'government', 'network']
+};
+
+/**
+ * Transportation and logistics preset - fleet, shipping, and mobility
+ */
+export const transportLogisticsPreset: Partial<OpenRedactionOptions> = {
+  includeNames: true,
+  includeEmails: true,
+  includePhones: true,
+  includeAddresses: true,
+  categories: ['personal', 'contact', 'transportation', 'logistics', 'vehicles', 'network']
+};
+
+/**
  * Get preset configuration by name
  */
 export function getPreset(name: string): Partial<OpenRedactionOptions> {
-  switch (name.toLowerCase()) {
+  const presetName = name.toLowerCase() as PresetName | string;
+
+  switch (presetName) {
     case 'gdpr':
       return gdprPreset;
     case 'hipaa':
       return hipaaPreset;
     case 'ccpa':
       return ccpaPreset;
+    case 'healthcare':
+    case 'healthcare-provider':
+      return healthcarePreset;
+    case 'healthcare-research':
+      return healthcareResearchPreset;
+    case 'finance':
+    case 'financial-services':
+      return financePreset;
+    case 'education':
+      return educationPreset;
+    case 'transport-logistics':
+    case 'transportation':
+    case 'logistics':
+      return transportLogisticsPreset;
     default:
       return {};
   }


### PR DESCRIPTION
## Summary
- add finance, education, healthcare, and transport/logistics presets with category-based filtering and aliases
- expose the expanded preset types/exports and allow config loader to resolve new openredaction:* presets
- document and surface the new presets in CLI help, README examples, and workspace README

## Testing
- npm test -w packages/core *(fails: caching high-volume performance expectation >10ms in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69288bb5e8088331b4affbe1d9aab96c)