### PR TITLE
Fix missing chunk files in published package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,12 +17,7 @@
     }
   },
   "files": [
-    "dist/index.js",
-    "dist/index.mjs",
-    "dist/index.d.ts",
-    "dist/index.d.mts",
-    "dist/index.cli.js",
-    "dist/cli/"
+    "dist"
   ],
   "scripts": {
     "build": "tsdown && node scripts/dual-types.js",

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -10,6 +10,9 @@ export default defineConfig([
     outDir: 'dist',
     external: ['react', 'express'],
     fixedExtension: false,
+    outputOptions: {
+      codeSplitting: false,
+    },
     outExtensions({ format }) {
       return { js: format === 'cjs' ? '.js' : '.mjs' };
     },
@@ -21,6 +24,9 @@ export default defineConfig([
     outDir: 'dist',
     dts: false,
     banner: '#!/usr/bin/env node',
+    outputOptions: {
+      codeSplitting: false,
+    },
   },
   // Pattern testing CLI build
   {
@@ -29,5 +35,8 @@ export default defineConfig([
     outDir: 'dist/cli',
     dts: false,
     banner: '#!/usr/bin/env node',
+    outputOptions: {
+      codeSplitting: false,
+    },
   },
 ]);


### PR DESCRIPTION
I tested your current 1.0.4 changes by publishing the package to npm under a junk name and still had issues with importing. This fixes it. The output looks like this:

<img width="455" height="285" alt="image" src="https://github.com/user-attachments/assets/10f53230-49f3-4faf-b716-449c17f0aa17" />

Disables code splitting in tsdown builds so that all code is bundled into single files (index.js, index.mjs, index.cli.cjs) rather than split into separate chunks. This fixes import errors where consumers couldn't find chunk files like document-ChTIy4sC.mjs that weren't included in the published package.

Also simplified the files array to include all of dist/ to ensure any build artifacts are published.
