### PR TITLE
feat(core): fix out-of-order range in regex Safari

### DIFF
--- a/packages/core/src/patterns/contact.ts
+++ b/packages/core/src/patterns/contact.ts
@@ -7,14 +7,14 @@ import { PIIPattern } from '../types';
 export const contactPatterns: PIIPattern[] = [
   {
     type: 'PHONE_UK_MOBILE',
-    regex: /\b(?:\+?44[\s\u00A0.-]?7\d{3}|0?7\d{3})[\s\u00A0.-]?\d{3}[\s\u00A0.-]?\d{3}\b/g,
+    regex: /\b(?:\+?44[\s\u00A0.\-]?7\d{3}|0?7\d{3})[\s\u00A0.\-]?\d{3}[\s\u00A0.\-]?\d{3}\b/g,
     priority: 90,
     placeholder: '[PHONE_UK_MOBILE_{n}]',
     description: 'UK mobile phone',
     severity: 'medium',
     validator: (value: string, context: string) => {
       // Normalize separators
-      const cleaned = value.replace(/[\s\u00A0().-]/g, '');
+      const cleaned = value.replace(/[\s\u00A0().\-]/g, '');
       
       // UK mobile: must start with 7 (or +447 or 07)
       const mobilePattern = /^(?:\+?44)?7\d{9}$/;
@@ -42,14 +42,14 @@ export const contactPatterns: PIIPattern[] = [
   },
   {
     type: 'PHONE_UK',
-    regex: /\b(?:\+?44[\s\u00A0.-]?(?:0)?\s*)?(?:\(?0?[1-9]\d{1,3}\)?[\s\u00A0.-]?\d{3,4}[\s\u00A0.-]?\d{3,4})(?:\s?(?:ext\.?|x)\s?\d{1,5})?\b/g,
+    regex: /\b(?:\+?44[\s\u00A0.\-]?(?:0)?\s*)?(?:\(?0?[1-9]\d{1,3}\)?[\s\u00A0.\-]?\d{3,4}[\s\u00A0.\-]?\d{3,4})(?:\s?(?:ext\.?|x)\s?\d{1,5})?\b/g,
     priority: 85,
     placeholder: '[PHONE_UK_{n}]',
     description: 'UK phone number',
     severity: 'medium',
     validator: (value: string, context: string) => {
       // Normalize separators
-      const cleaned = value.replace(/[\s\u00A0().-]/g, '').replace(/ext|x/i, '');
+      const cleaned = value.replace(/[\s\u00A0().\-]/g, '').replace(/ext|x/i, '');
       
       // UK landline: must start with 0 or +44, then area code (1-4 digits starting with 1-9), then 6-7 digits
       const ukPattern = /^(?:\+?44)?0?[1-9]\d{1,3}\d{6,7}$/;
@@ -77,14 +77,14 @@ export const contactPatterns: PIIPattern[] = [
   },
   {
     type: 'PHONE_US',
-    regex: /\b(?:\+1[\s\u00A0.-]?)?(?:\(\d{3}\)|\d{3})[\s\u00A0.-]?\d{3}[\s\u00A0.-]?\d{4}(?:\s?(?:ext\.?|x)\s?\d{1,6})?\b/g,
+    regex: /\b(?:\+1[\s\u00A0.\-]?)?(?:\(\d{3}\)|\d{3})[\s\u00A0.\-]?\d{3}[\s\u00A0.\-]?\d{4}(?:\s?(?:ext\.?|x)\s?\d{1,6})?\b/g,
     priority: 85,
     placeholder: '[PHONE_US_{n}]',
     description: 'US phone number',
     severity: 'medium',
     validator: (value: string, context: string) => {
       // Normalize separators
-      const cleaned = value.replace(/[\s\u00A0().-]/g, '').replace(/ext|x/i, '');
+      const cleaned = value.replace(/[\s\u00A0().\-]/g, '').replace(/ext|x/i, '');
       
       // US phone: must be 10 digits (with optional +1 prefix)
       const usPattern = /^(?:\+?1)?\d{10}$/;
@@ -132,7 +132,7 @@ export const contactPatterns: PIIPattern[] = [
     severity: 'medium',
     validator: (value: string, context: string) => {
       // Normalize separators
-      const cleaned = value.replace(/[\s\u00A0().-]/g, '').replace(/ext|x/i, '');
+      const cleaned = value.replace(/[\s\u00A0().\-]/g, '').replace(/ext|x/i, '');
       
       // International: must start with + and have 7-15 digits total
       if (!cleaned.startsWith('+')) return false;
@@ -177,14 +177,14 @@ export const contactPatterns: PIIPattern[] = [
   },
   {
     type: 'POSTCODE_UK',
-    regex: /\b([A-Z]{1,2}\d{1,2}[A-Z]?[\s\u00A0.-]?\d[A-Z]{2})\b/g,
+    regex: /\b([A-Z]{1,2}\d{1,2}[A-Z]?[\s\u00A0.\-]?\d[A-Z]{2})\b/g,
     priority: 75,
     placeholder: '[POSTCODE_{n}]',
     description: 'UK postcode',
     severity: 'low',
     validator: (value: string, _context: string) => {
       // Normalize separators for validation
-      const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+      const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
       
       // UK postcode format: 1-2 letters, 1-2 digits, optional letter, space/dash, digit, 2 letters
       // After normalization: 5-7 characters total
@@ -202,14 +202,14 @@ export const contactPatterns: PIIPattern[] = [
   },
   {
     type: 'ZIP_CODE_US',
-    regex: /\b(\d{5}(?:[\s\u00A0.-]\d{4})?)\b/g,
+    regex: /\b(\d{5}(?:[\s\u00A0.\-]\d{4})?)\b/g,
     priority: 70,
     placeholder: '[ZIP_{n}]',
     description: 'US ZIP code',
     severity: 'low',
     validator: (value: string, context: string) => {
       // Normalize separators
-      const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+      const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
       
       // Must be 5 digits (ZIP) or 9 digits (ZIP+4)
       if (!/^\d{5}$/.test(cleaned) && !/^\d{9}$/.test(cleaned)) {

--- a/packages/core/src/patterns/digital-identity.ts
+++ b/packages/core/src/patterns/digital-identity.ts
@@ -19,7 +19,7 @@ export const DISCORD_USER_ID: PIIPattern = {
   description: 'Discord user ID (Snowflake format)',
   validator: (value: string, context: string) => {
     // Normalize separators (though Discord IDs typically don't have them)
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
     
     // Must be 17-19 digits after normalization
     if (cleaned.length < 17 || cleaned.length > 19) return false;
@@ -44,7 +44,7 @@ export const STEAM_ID64: PIIPattern = {
   description: 'Steam 64-bit user ID',
   validator: (value: string, context: string) => {
     // Normalize separators
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
     
     if (!cleaned.startsWith('765') || cleaned.length !== 17) return false;
 
@@ -267,7 +267,7 @@ export const PSN_ID: PIIPattern = {
  */
 export const NINTENDO_FRIEND_CODE: PIIPattern = {
   type: 'NINTENDO_FRIEND_CODE',
-  regex: /\bSW[-\s]?(\d{4}[-\s]?\d{4}[-\s]?\d{4})\b/gi,
+  regex: /\bSW[\-\s]?(\d{4}[\-\s]?\d{4}[\-\s]?\d{4})\b/gi,
   placeholder: '[NINTENDO_FC_{n}]',
   priority: 90,
   severity: 'medium',

--- a/packages/core/src/patterns/financial.ts
+++ b/packages/core/src/patterns/financial.ts
@@ -13,11 +13,11 @@ import {
 export const financialPatterns: PIIPattern[] = [
   {
     type: 'CREDIT_CARD',
-    regex: /(?<!\d)(?:(?:\d{4}[\s\u00A0.-]?){3}\d{4}|\d{4}[\s\u00A0.-]?\d{6}[\s\u00A0.-]?\d{5})(?!\d)/g,
+    regex: /(?<!\d)(?:(?:\d{4}[\s\u00A0.\-]?){3}\d{4}|\d{4}[\s\u00A0.\-]?\d{6}[\s\u00A0.\-]?\d{5})(?!\d)/g,
     priority: 100,
     validator: (match: string, context: string) => {
       // Normalize separators before Luhn validation
-      const cleaned = match.replace(/[\s\u00A0.-]/g, '');
+      const cleaned = match.replace(/[\s\u00A0.\-]/g, '');
       
       // Must be 13-19 digits after normalization
       if (!/^\d{13,19}$/.test(cleaned)) {
@@ -45,11 +45,11 @@ export const financialPatterns: PIIPattern[] = [
   },
   {
     type: 'IBAN',
-    regex: /\b([A-Z]{2}\d{2}(?:[ \u00A0.-]?[A-Z0-9]){11,30})\b/gi,
+    regex: /\b([A-Z]{2}\d{2}(?:[ \u00A0.\-]?[A-Z0-9]){11,30})\b/gi,
     priority: 95,
     validator: (match: string, context: string) => {
       // Normalize separators before IBAN validation
-      const cleaned = match.replace(/[\s\u00A0.-]/g, '').toUpperCase();
+      const cleaned = match.replace(/[\s\u00A0.\-]/g, '').toUpperCase();
       
       // Must start with 2 letters (country code) and 2 digits (check digits)
       if (!/^[A-Z]{2}\d{2}/.test(cleaned)) {
@@ -82,7 +82,7 @@ export const financialPatterns: PIIPattern[] = [
     severity: 'high',
     validator: (value: string, context: string) => {
       // Normalize separators
-      const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+      const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
       
       // UK account numbers: 8 digits (4-4 format) or 10 digits (2-2-4 format)
       if (!/^\d{8}$/.test(cleaned) && !/^\d{10}$/.test(cleaned)) {
@@ -106,11 +106,11 @@ export const financialPatterns: PIIPattern[] = [
   },
   {
     type: 'SORT_CODE_UK',
-    regex: /\b(?:sort[\s\u00A0-]*code|SC)[:\s\u00A0.-]*((?:\d{2}[\s\u00A0.-]?){2}\d{2})\b/gi,
+    regex: /\b(?:sort[\s\u00A0-]*code|SC)[:\s\u00A0.\-]*((?:\d{2}[\s\u00A0.\-]?){2}\d{2})\b/gi,
     priority: 90,
     validator: (match: string, context: string) => {
       // Normalize separators before validation
-      const cleaned = match.replace(/[\s\u00A0.-]/g, '');
+      const cleaned = match.replace(/[\s\u00A0.\-]/g, '');
       
       // Must be exactly 6 digits
       if (!/^\d{6}$/.test(cleaned)) {
@@ -136,11 +136,11 @@ export const financialPatterns: PIIPattern[] = [
   },
   {
     type: 'ROUTING_NUMBER_US',
-    regex: /\b(?:routing|RTN|ABA)[-\s\u00A0]*(?:number|no|num)?[-\s\u00A0.:#]*((?:\d[\s\u00A0.-]?){9})\b/gi,
+    regex: /\b(?:routing|RTN|ABA)[\-\s\u00A0]*(?:number|no|num)?[\-\s\u00A0.:#]*((?:\d[\s\u00A0.\-]?){9})\b/gi,
     priority: 90,
     validator: (match: string, context: string) => {
       // Normalize separators before validation
-      const cleaned = match.replace(/[\s\u00A0.-]/g, '');
+      const cleaned = match.replace(/[\s\u00A0.\-]/g, '');
       
       // Must be exactly 9 digits
       if (!/^\d{9}$/.test(cleaned)) {
@@ -173,7 +173,7 @@ export const financialPatterns: PIIPattern[] = [
     severity: 'high',
     validator: (value: string, context: string) => {
       // Normalize separators
-      const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+      const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
       
       // Must be 3 or 4 digits
       if (!/^\d{3,4}$/.test(cleaned)) {
@@ -194,14 +194,14 @@ export const financialPatterns: PIIPattern[] = [
   },
   {
     type: 'IFSC',
-    regex: /\b([A-Z]{4})[-\s\u00A0.]?0[-\s\u00A0.]?([A-Z0-9]{6})\b/gi,
+    regex: /\b([A-Z]{4})[\-\s\u00A0.]?0[\-\s\u00A0.]?([A-Z0-9]{6})\b/gi,
     priority: 90,
     placeholder: '[IFSC_{n}]',
     description: 'Indian Financial System Code',
     severity: 'high',
     validator: (value: string, context: string) => {
       // Normalize separators
-      const cleaned = value.replace(/[\s\u00A0.-]/g, '').toUpperCase();
+      const cleaned = value.replace(/[\s\u00A0.\-]/g, '').toUpperCase();
       
       // Must match IFSC format: 4 letters + 0 + 6 alphanumeric
       if (!/^[A-Z]{4}0[A-Z0-9]{6}$/.test(cleaned)) {
@@ -250,7 +250,7 @@ export const financialPatterns: PIIPattern[] = [
     priority: 90,
     validator: (match: string, context: string) => {
       // Normalize separators
-      const cleaned = match.replace(/[\s\u00A0.-]/g, '');
+      const cleaned = match.replace(/[\s\u00A0.\-]/g, '');
       
       // Must be exactly 6 digits
       if (!/^\d{6}$/.test(cleaned)) {

--- a/packages/core/src/patterns/financial/crypto-extended.ts
+++ b/packages/core/src/patterns/financial/crypto-extended.ts
@@ -19,7 +19,7 @@ export const SOLANA_ADDRESS: PIIPattern = {
   description: 'Solana (SOL) cryptocurrency address',
   validator: (value: string, context: string) => {
     // Normalize (remove any whitespace that might have been introduced)
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
     
     // Length validation
     if (cleaned.length < 32 || cleaned.length > 44) return false;
@@ -65,7 +65,7 @@ export const POLKADOT_ADDRESS: PIIPattern = {
   description: 'Polkadot (DOT) cryptocurrency address',
   validator: (value: string, context: string) => {
     // Normalize (remove any whitespace)
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
     
     // Length validation
     if (cleaned.length < 47 || cleaned.length > 48) return false;
@@ -101,7 +101,7 @@ export const POLKADOT_ADDRESS: PIIPattern = {
  */
 export const AVALANCHE_ADDRESS: PIIPattern = {
   type: 'AVALANCHE_ADDRESS',
-  regex: /\b([XPC][-\s\u00A0]?(?:avax)?[a-z0-9]{38,43})\b/gi,
+  regex: /\b([XPC][\-\s\u00A0]?(?:avax)?[a-z0-9]{38,43})\b/gi,
   placeholder: '[AVAX_ADDR_{n}]',
   priority: 85,
   severity: 'high',
@@ -146,7 +146,7 @@ export const COSMOS_ADDRESS: PIIPattern = {
   description: 'Cosmos (ATOM) cryptocurrency address',
   validator: (value: string, context: string) => {
     // Normalize (remove any whitespace)
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '').toLowerCase();
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '').toLowerCase();
     
     // Must start with cosmos1
     if (!cleaned.startsWith('cosmos1')) return false;
@@ -189,7 +189,7 @@ export const ALGORAND_ADDRESS: PIIPattern = {
   description: 'Algorand (ALGO) cryptocurrency address',
   validator: (value: string, context: string) => {
     // Normalize (remove any whitespace, convert to uppercase)
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '').toUpperCase();
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '').toUpperCase();
     
     // Must be exactly 58 characters after normalization
     if (cleaned.length !== 58) return false;
@@ -227,7 +227,7 @@ export const TEZOS_ADDRESS: PIIPattern = {
   description: 'Tezos (XTZ) cryptocurrency address',
   validator: (value: string, context: string) => {
     // Normalize (remove any whitespace)
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
     
     // Must start with tz1, tz2, or tz3
     if (!/^tz[123]/.test(cleaned)) return false;
@@ -270,7 +270,7 @@ export const POLYGON_ADDRESS: PIIPattern = {
   description: 'Polygon (MATIC) cryptocurrency address',
   validator: (value: string, context: string) => {
     // Normalize (remove any whitespace)
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
     
     // Must start with 0x and be 42 chars total after normalization
     if (!cleaned.startsWith('0x') || cleaned.length !== 42) return false;
@@ -315,7 +315,7 @@ export const BINANCE_CHAIN_ADDRESS: PIIPattern = {
   description: 'Binance Smart Chain (BNB) address',
   validator: (value: string, context: string) => {
     // Normalize (remove any whitespace)
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
     
     // Must start with 0x and be 42 chars total after normalization
     if (!cleaned.startsWith('0x') || cleaned.length !== 42) return false;

--- a/packages/core/src/patterns/government.ts
+++ b/packages/core/src/patterns/government.ts
@@ -13,11 +13,11 @@ import {
 export const governmentPatterns: PIIPattern[] = [
   {
     type: 'SSN',
-    regex: /\b(?:SSN|social\s+security)\b[:\s\u00A0#-]*([0-9]{3}[\s\u00A0.-]?[0-9]{2}[\s\u00A0.-]?[0-9]{4})\b/gi,
+    regex: /\b(?:SSN|social\s+security)\b[:\s\u00A0#-]*([0-9]{3}[\s\u00A0.\-]?[0-9]{2}[\s\u00A0.\-]?[0-9]{4})\b/gi,
     priority: 100,
     validator: (match: string, context: string) => {
       // Normalize separators
-      const cleaned = match.replace(/[\s\u00A0.-]/g, '');
+      const cleaned = match.replace(/[\s\u00A0.\-]/g, '');
 
       // Must be exactly 9 digits after normalization
       if (!/^\d{9}$/.test(cleaned)) {
@@ -51,11 +51,11 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'PASSPORT_UK',
-    regex: /\b(?:passport|pass)[:\s\u00A0#-]*((?:\d{3}[\s\u00A0.-]?){2}\d{3})\b/gi,
+    regex: /\b(?:passport|pass)[:\s\u00A0#-]*((?:\d{3}[\s\u00A0.\-]?){2}\d{3})\b/gi,
     priority: 95,
     validator: (match: string, context: string) => {
       // Normalize separators
-      const cleaned = match.replace(/[\s\u00A0.-]/g, '');
+      const cleaned = match.replace(/[\s\u00A0.\-]/g, '');
 
       // Must be exactly 9 digits after normalization
       if (!/^\d{9}$/.test(cleaned)) {
@@ -87,14 +87,14 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'PASSPORT_US',
-    regex: /\b(?:passport|pass)[:\s\u00A0#-]*(([A-Z0-9][\s\u00A0.-]?){5,8}[A-Z0-9])\b/gi,
+    regex: /\b(?:passport|pass)[:\s\u00A0#-]*(([A-Z0-9][\s\u00A0.\-]?){5,8}[A-Z0-9])\b/gi,
     priority: 95,
     placeholder: '[PASSPORT_{n}]',
     description: 'US Passport number',
     severity: 'high',
     validator: (value: string, context: string) => {
       // Normalize separators
-      const cleaned = value.replace(/[\s\u00A0.-]/g, '').toUpperCase();
+      const cleaned = value.replace(/[\s\u00A0.\-]/g, '').toUpperCase();
 
       // US passports are 6-9 characters (typically 9)
       if (cleaned.length < 6 || cleaned.length > 9) {
@@ -123,11 +123,11 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'NATIONAL_INSURANCE_UK',
-    regex: /\b(?:NI\b|NINO|national\s+insurance)[:\s\u00A0#-]*([A-CEGHJ-PR-TW-Z]{2}(?:[\s\u00A0.-]?\d{2}){3}[\s\u00A0.-]?[A-D])\b/gi,
+    regex: /\b(?:NI\b|NINO|national\s+insurance)[:\s\u00A0#-]*([A-CEGHJ-PR-TW-Z]{2}(?:[\s\u00A0.\-]?\d{2}){3}[\s\u00A0.\-]?[A-D])\b/gi,
     priority: 100,
     validator: (match: string, context: string) => {
       // Normalize separators
-      const cleaned = match.replace(/[\s\u00A0.-]/g, '').toUpperCase();
+      const cleaned = match.replace(/[\s\u00A0.\-]/g, '').toUpperCase();
 
       // Must be exactly 9 characters after normalization
       if (!/^[A-CEGHJ-PR-TW-Z]{2}\d{6}[A-D]$/.test(cleaned)) {
@@ -159,11 +159,11 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'NHS_NUMBER',
-    regex: /\b(?:NHS|nhs number)[:\s\u00A0#-]*((?:\d{3}[\s\u00A0.-]?){2}\d{4})\b/gi,
+    regex: /\b(?:NHS|nhs number)[:\s\u00A0#-]*((?:\d{3}[\s\u00A0.\-]?){2}\d{4})\b/gi,
     priority: 95,
     validator: (match: string, context: string) => {
       // Normalize separators
-      const cleaned = match.replace(/[\s\u00A0.-]/g, '');
+      const cleaned = match.replace(/[\s\u00A0.\-]/g, '');
 
       // Must be exactly 10 digits after normalization
       if (!/^\d{10}$/.test(cleaned)) {
@@ -195,14 +195,14 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'DRIVING_LICENSE_UK',
-    regex: /\b(?:DL|DRIVING|DRIVER(?:'S)?|LICEN[SC]E)?[\s\u00A0#:-]*(?:NO|NUM(?:BER)?|ID)?[\s\u00A0#:-]*([A-Z]{5}[\s\u00A0.-]?\d{2}[\s\u00A0.-]?\d{2}[\s\u00A0.-]?\d{2}[\s\u00A0.-]?[A-Z]{2}[\s\u00A0.-]?\d[\s\u00A0.-]?[A-Z]{2})\b/gi,
+    regex: /\b(?:DL|DRIVING|DRIVER(?:'S)?|LICEN[SC]E)?[\s\u00A0#:-]*(?:NO|NUM(?:BER)?|ID)?[\s\u00A0#:-]*([A-Z]{5}[\s\u00A0.\-]?\d{2}[\s\u00A0.\-]?\d{2}[\s\u00A0.\-]?\d{2}[\s\u00A0.\-]?[A-Z]{2}[\s\u00A0.\-]?\d[\s\u00A0.\-]?[A-Z]{2})\b/gi,
     priority: 90,
     placeholder: '[DRIVING_LICENSE_{n}]',
     description: 'UK Driving License',
     severity: 'high',
     validator: (value: string, context: string) => {
       // Normalize separators
-      const normalized = value.replace(/[\s\u00A0.-]/g, '').toUpperCase();
+      const normalized = value.replace(/[\s\u00A0.\-]/g, '').toUpperCase();
 
       // Must be exactly 16 characters after normalization
       if (!/^[A-Z]{5}\d{6}[A-Z]{2}\d[A-Z]{2}$/.test(normalized)) {
@@ -237,14 +237,14 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'DRIVING_LICENSE_US',
-    regex: /\b(?:DL|driver(?:'s)?\slicense)[:\s\u00A0#-]*([A-Z0-9](?:[A-Z0-9][\s\u00A0.-]?){3,18}[A-Z0-9])\b/gi,
+    regex: /\b(?:DL|driver(?:'s)?\slicense)[:\s\u00A0#-]*([A-Z0-9](?:[A-Z0-9][\s\u00A0.\-]?){3,18}[A-Z0-9])\b/gi,
     priority: 90,
     placeholder: '[DRIVING_LICENSE_{n}]',
     description: 'US Driving License',
     severity: 'high',
     validator: (value: string, context: string) => {
       // Normalize separators
-      const cleaned = value.replace(/[\s\u00A0.-]/g, '').toUpperCase();
+      const cleaned = value.replace(/[\s\u00A0.\-]/g, '').toUpperCase();
 
       // US driver's licenses vary by state, typically 6-17 characters
       if (cleaned.length < 6 || cleaned.length > 17) {
@@ -273,14 +273,14 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'TAX_ID',
-    regex: /\b(?:TIN|tax id|EIN)[:\s\u00A0#-]*(\d{2}(?:[\s\u00A0.-]?\d){7})\b/gi,
+    regex: /\b(?:TIN|tax id|EIN)[:\s\u00A0#-]*(\d{2}(?:[\s\u00A0.\-]?\d){7})\b/gi,
     priority: 95,
     placeholder: '[TAX_ID_{n}]',
     description: 'Tax identification number',
     severity: 'high',
     validator: (value: string, context: string) => {
       // Normalize separators
-      const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+      const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
 
       // Must be exactly 9 digits after normalization
       if (!/^\d{9}$/.test(cleaned)) {
@@ -335,7 +335,7 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'TRAVEL_DOCUMENT_NUMBER',
-    regex: /\b(?:TRAVEL\s+DOC(?:UMENT)?|TD)[:\s#-]*([A-Z0-9](?:[A-Z0-9][\s\u00A0.-]?){4,13}[A-Z0-9])\b/gi,
+    regex: /\b(?:TRAVEL\s+DOC(?:UMENT)?|TD)[:\s#-]*([A-Z0-9](?:[A-Z0-9][\s\u00A0.\-]?){4,13}[A-Z0-9])\b/gi,
     priority: 92,
     placeholder: '[TRAVEL_DOC_{n}]',
     description: 'Travel document numbers',
@@ -346,7 +346,7 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'VISA_NUMBER',
-    regex: /\b(?:VISA)[:\s#-]*([A-Z0-9](?:[A-Z0-9][\s\u00A0.-]?){6,10}[A-Z0-9])\b/gi,
+    regex: /\b(?:VISA)[:\s#-]*([A-Z0-9](?:[A-Z0-9][\s\u00A0.\-]?){6,10}[A-Z0-9])\b/gi,
     priority: 92,
     placeholder: '[VISA_{n}]',
     description: 'Visa numbers',
@@ -357,7 +357,7 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'IMMIGRATION_NUMBER',
-    regex: /\b(?:IMMIGRATION|ALIEN|A-NUMBER|A#)[:\s#-]*([A-Z]?(?:\d[\s\u00A0.-]?){7,9})\b/gi,
+    regex: /\b(?:IMMIGRATION|ALIEN|A-NUMBER|A#)[:\s#-]*([A-Z]?(?:\d[\s\u00A0.\-]?){7,9})\b/gi,
     priority: 92,
     placeholder: '[IMMIGRATION_{n}]',
     description: 'Immigration and alien registration numbers',
@@ -365,7 +365,7 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'BORDER_CROSSING_CARD',
-    regex: /\b(?:BCC|BORDER\s+CROSSING)[:\s#-]*([A-Z0-9](?:[A-Z0-9\s\u00A0.-]?){8,13}[A-Z0-9])\b/gi,
+    regex: /\b(?:BCC|BORDER\s+CROSSING)[:\s#-]*([A-Z0-9](?:[A-Z0-9\s\u00A0.\-]?){8,13}[A-Z0-9])\b/gi,
     priority: 90,
     placeholder: '[BCC_{n}]',
     description: 'Border crossing card numbers',
@@ -376,7 +376,7 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'UTR_UK',
-    regex: /\b(?:UTR|unique taxpayer reference)[:\s#-]*((?:\d[\s\u00A0.-]?){10})\b/gi,
+    regex: /\b(?:UTR|unique taxpayer reference)[:\s#-]*((?:\d[\s\u00A0.\-]?){10})\b/gi,
     priority: 95,
     validator: (match) => {
       // UK UTR: 10 digits, typically issued in sequence
@@ -389,11 +389,11 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'VAT_NUMBER',
-    regex: /\b(?:VAT|vat number)[:\s#-]*([A-Z]{2}(?:[\s\u00A0.-]?[A-Z0-9]){7,12})\b/gi,
+    regex: /\b(?:VAT|vat number)[:\s#-]*([A-Z]{2}(?:[\s\u00A0.\-]?[A-Z0-9]){7,12})\b/gi,
     priority: 90,
     validator: (match) => {
       // VAT format varies by country (GB: 9 digits, DE: 9 digits, FR: 11 chars, etc.)
-      const cleaned = match.replace(/[\s\u00A0.-]/g, '');
+      const cleaned = match.replace(/[\s\u00A0.\-]/g, '');
 
       // Check for valid country codes
       const countryCode = cleaned.substring(0, 2).toUpperCase();
@@ -439,7 +439,7 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'ITIN',
-    regex: /\b(?:ITIN|individual taxpayer)[:\s#]*(9\d{2}[-\s]?[7-8]\d[-\s]?\d{4})\b/gi,
+    regex: /\b(?:ITIN|individual taxpayer)[:\s#]*(9\d{2}[\-\s]?[7-8]\d[\-\s]?\d{4})\b/gi,
     priority: 100,
     validator: (match) => {
       // ITIN: 9XX-7X-XXXX or 9XX-8X-XXXX format
@@ -465,7 +465,7 @@ export const governmentPatterns: PIIPattern[] = [
   },
   {
     type: 'SIN_CA',
-    regex: /\b(?:SIN|social insurance)[:\s#]*(\d{3}[-\s]?\d{3}[-\s]?\d{3})\b/gi,
+    regex: /\b(?:SIN|social insurance)[:\s#]*(\d{3}[\-\s]?\d{3}[\-\s]?\d{3})\b/gi,
     priority: 100,
     validator: (match) => {
       // Canadian SIN: 9 digits using Luhn algorithm

--- a/packages/core/src/patterns/industries/aviation.ts
+++ b/packages/core/src/patterns/industries/aviation.ts
@@ -11,7 +11,7 @@ import type { PIIPattern } from '../../types';
  */
 export const IATA_AIRPORT_CODE: PIIPattern = {
   type: 'IATA_AIRPORT_CODE',
-  regex: /\b(?:AIRPORT|FROM|TO|VIA|IATA)[-\s]?(?:CODE)?[-\s]?[:#]?\s*([A-Z]{3})\b/gi,
+  regex: /\b(?:AIRPORT|FROM|TO|VIA|IATA)[\-\s]?(?:CODE)?[\-\s]?[:#]?\s*([A-Z]{3})\b/gi,
   placeholder: '[AIRPORT_{n}]',
   priority: 75,
   severity: 'low',
@@ -27,7 +27,7 @@ export const IATA_AIRPORT_CODE: PIIPattern = {
  */
 export const FLIGHT_NUMBER: PIIPattern = {
   type: 'FLIGHT_NUMBER',
-  regex: /\b(?:FLIGHT|FLT)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z]{2,3}\s?\d{1,4})\b/gi,
+  regex: /\b(?:FLIGHT|FLT)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z]{2,3}\s?\d{1,4})\b/gi,
   placeholder: '[FLIGHT_{n}]',
   priority: 80,
   severity: 'low',
@@ -70,7 +70,7 @@ export const AIRCRAFT_TAIL_NUMBER: PIIPattern = {
  */
 export const AIRCRAFT_REGISTRATION: PIIPattern = {
   type: 'AIRCRAFT_REGISTRATION',
-  regex: /\b(?:REGISTRATION|REG|TAIL)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z]{1,2}-[A-Z0-9]{3,5})\b/gi,
+  regex: /\b(?:REGISTRATION|REG|TAIL)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z]{1,2}-[A-Z0-9]{3,5})\b/gi,
   placeholder: '[AIRCRAFT_REG_{n}]',
   priority: 85,
   severity: 'medium',
@@ -86,7 +86,7 @@ export const AIRCRAFT_REGISTRATION: PIIPattern = {
  */
 export const FAA_AIRMAN_CERTIFICATE: PIIPattern = {
   type: 'FAA_AIRMAN_CERTIFICATE',
-  regex: /\b(?:FAA|AIRMAN|PILOT)[-\s]?(?:CERT(?:IFICATE)?|LICENSE)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{7,8})\b/gi,
+  regex: /\b(?:FAA|AIRMAN|PILOT)[\-\s]?(?:CERT(?:IFICATE)?|LICENSE)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{7,8})\b/gi,
   placeholder: '[FAA_CERT_{n}]',
   priority: 85,
   severity: 'medium',
@@ -105,7 +105,7 @@ export const FAA_AIRMAN_CERTIFICATE: PIIPattern = {
  */
 export const ICAO_AIRCRAFT_TYPE: PIIPattern = {
   type: 'ICAO_AIRCRAFT_TYPE',
-  regex: /\b(?:AIRCRAFT|TYPE|ICAO)[-\s]?(?:CODE|DESIGNATOR)?[-\s]?[:#]?\s*([A-Z][0-9][A-Z0-9]{1,2})\b/gi,
+  regex: /\b(?:AIRCRAFT|TYPE|ICAO)[\-\s]?(?:CODE|DESIGNATOR)?[\-\s]?[:#]?\s*([A-Z][0-9][A-Z0-9]{1,2})\b/gi,
   placeholder: '[AIRCRAFT_TYPE_{n}]',
   priority: 70,
   severity: 'low',
@@ -121,7 +121,7 @@ export const ICAO_AIRCRAFT_TYPE: PIIPattern = {
  */
 export const AIRCRAFT_MODE_S: PIIPattern = {
   type: 'AIRCRAFT_MODE_S',
-  regex: /\b(?:MODE\s?S|ICAO\s?ADDRESS)[-\s]?[:#]?\s*([A-F0-9]{6})\b/gi,
+  regex: /\b(?:MODE\s?S|ICAO\s?ADDRESS)[\-\s]?[:#]?\s*([A-F0-9]{6})\b/gi,
   placeholder: '[MODE_S_{n}]',
   priority: 85,
   severity: 'medium',
@@ -140,7 +140,7 @@ export const AIRCRAFT_MODE_S: PIIPattern = {
  */
 export const AIRLINE_BOOKING_REFERENCE: PIIPattern = {
   type: 'AIRLINE_BOOKING_REFERENCE',
-  regex: /\b(?:BOOKING|RESERVATION|LOCATOR|REFERENCE)[-\s]?(?:CODE|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6})\b/gi,
+  regex: /\b(?:BOOKING|RESERVATION|LOCATOR|REFERENCE)[\-\s]?(?:CODE|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6})\b/gi,
   placeholder: '[BOOKING_REF_{n}]',
   priority: 85,
   severity: 'medium',
@@ -156,7 +156,7 @@ export const AIRLINE_BOOKING_REFERENCE: PIIPattern = {
  */
 export const IATA_AIRLINE_CODE: PIIPattern = {
   type: 'IATA_AIRLINE_CODE',
-  regex: /\b(?:AIRLINE|CARRIER)[-\s]?(?:CODE|IATA)?[-\s]?[:#]?\s*([A-Z]{2})\b/gi,
+  regex: /\b(?:AIRLINE|CARRIER)[\-\s]?(?:CODE|IATA)?[\-\s]?[:#]?\s*([A-Z]{2})\b/gi,
   placeholder: '[AIRLINE_{n}]',
   priority: 70,
   severity: 'low',

--- a/packages/core/src/patterns/industries/charitable.ts
+++ b/packages/core/src/patterns/industries/charitable.ts
@@ -68,7 +68,7 @@ export const US_EIN: PIIPattern = {
   description: 'US Employer Identification Numbers (nonprofit tax IDs)',
   validator: (value: string, context: string) => {
     const digits = value.replace(/\D/g, '');
-    return digits.length === 9 && /nonprofit|charity|501\(c\)|tax[-\s]exempt|foundation/i.test(context);
+    return digits.length === 9 && /nonprofit|charity|501\(c\)|tax[\-\s]exempt|foundation/i.test(context);
   }
 };
 

--- a/packages/core/src/patterns/industries/education.ts
+++ b/packages/core/src/patterns/industries/education.ts
@@ -10,7 +10,7 @@ import { PIIPattern } from '../../types';
  */
 export const STUDENT_ID: PIIPattern = {
   type: 'STUDENT_ID',
-  regex: /\b(?:STUDENT|PUPIL|SCHOLAR)[-\s]?(?:ID|NUM(?:BER)?|NO)?[-\s]?[:#]?\s*([A-Z]{0,2}\d{6,10})\b/gi,
+  regex: /\b(?:STUDENT|PUPIL|SCHOLAR)[\-\s]?(?:ID|NUM(?:BER)?|NO)?[\-\s]?[:#]?\s*([A-Z]{0,2}\d{6,10})\b/gi,
   placeholder: '[STUDENT_ID_{n}]',
   priority: 90,
   severity: 'high',
@@ -22,7 +22,7 @@ export const STUDENT_ID: PIIPattern = {
  */
 export const UNIVERSITY_ID: PIIPattern = {
   type: 'UNIVERSITY_ID',
-  regex: /\b(?:UNIVERSITY|COLLEGE|UNI)[-\s]?(?:ID|NUM(?:BER)?|NO)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:UNIVERSITY|COLLEGE|UNI)[\-\s]?(?:ID|NUM(?:BER)?|NO)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[UNI_ID_{n}]',
   priority: 90,
   severity: 'high',
@@ -56,7 +56,7 @@ export const COURSE_CODE: PIIPattern = {
  */
 export const GRADE_REFERENCE: PIIPattern = {
   type: 'GRADE_REFERENCE',
-  regex: /\b(?:GPA|GRADE[-\s]?POINT[-\s]?AVERAGE)[-\s]?[:#]?\s*((?:[0-4]\.\d{1,2})|(?:\d\.\d{2}))\b/gi,
+  regex: /\b(?:GPA|GRADE[\-\s]?POINT[\-\s]?AVERAGE)[\-\s]?[:#]?\s*((?:[0-4]\.\d{1,2})|(?:\d\.\d{2}))\b/gi,
   placeholder: '[GPA_{n}]',
   priority: 80,
   severity: 'high',
@@ -68,7 +68,7 @@ export const GRADE_REFERENCE: PIIPattern = {
  */
 export const TRANSCRIPT_ID: PIIPattern = {
   type: 'TRANSCRIPT_ID',
-  regex: /\b(?:TRANSCRIPT)[-\s]?(?:ID|NUM(?:BER)?|NO|REF)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:TRANSCRIPT)[\-\s]?(?:ID|NUM(?:BER)?|NO|REF)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[TRANSCRIPT_{n}]',
   priority: 85,
   severity: 'high',
@@ -80,7 +80,7 @@ export const TRANSCRIPT_ID: PIIPattern = {
  */
 export const LIBRARY_CARD: PIIPattern = {
   type: 'LIBRARY_CARD',
-  regex: /\b(?:LIBRARY)[-\s]?(?:CARD|ID|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:LIBRARY)[\-\s]?(?:CARD|ID|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[LIBRARY_{n}]',
   priority: 70,
   severity: 'medium',
@@ -92,7 +92,7 @@ export const LIBRARY_CARD: PIIPattern = {
  */
 export const FACULTY_ID: PIIPattern = {
   type: 'FACULTY_ID',
-  regex: /\b(?:FACULTY|TEACHER|INSTRUCTOR|PROFESSOR|STAFF)[-\s]?(?:ID|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z]{1,2}\d{6,10})\b/gi,
+  regex: /\b(?:FACULTY|TEACHER|INSTRUCTOR|PROFESSOR|STAFF)[\-\s]?(?:ID|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z]{1,2}\d{6,10})\b/gi,
   placeholder: '[FACULTY_{n}]',
   priority: 85,
   severity: 'high',
@@ -107,7 +107,7 @@ export const FACULTY_ID: PIIPattern = {
  */
 export const ENROLLMENT_NUMBER: PIIPattern = {
   type: 'ENROLLMENT_NUMBER',
-  regex: /\b(?:ENROLLMENT|REGISTRATION)[-\s]?(?:NO|NUM(?:BER)?|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:ENROLLMENT|REGISTRATION)[\-\s]?(?:NO|NUM(?:BER)?|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[ENROLLMENT_{n}]',
   priority: 80,
   severity: 'high',
@@ -119,7 +119,7 @@ export const ENROLLMENT_NUMBER: PIIPattern = {
  */
 export const FINANCIAL_AID_ID: PIIPattern = {
   type: 'FINANCIAL_AID_ID',
-  regex: /\b(?:FINANCIAL[-\s]?AID|FAFSA|AID[-\s]?APPLICATION)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:FINANCIAL[\-\s]?AID|FAFSA|AID[\-\s]?APPLICATION)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[AID_{n}]',
   priority: 90,
   severity: 'high',
@@ -131,7 +131,7 @@ export const FINANCIAL_AID_ID: PIIPattern = {
  */
 export const DEGREE_NUMBER: PIIPattern = {
   type: 'DEGREE_NUMBER',
-  regex: /\b(?:DEGREE|DIPLOMA|CERTIFICATE)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
+  regex: /\b(?:DEGREE|DIPLOMA|CERTIFICATE)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
   placeholder: '[DEGREE_{n}]',
   priority: 80,
   severity: 'high',
@@ -146,7 +146,7 @@ export const DEGREE_NUMBER: PIIPattern = {
  */
 export const EXAM_ID: PIIPattern = {
   type: 'EXAM_ID',
-  regex: /\b(?:EXAM|TEST|QUIZ|ASSESSMENT)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:EXAM|TEST|QUIZ|ASSESSMENT)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[EXAM_{n}]',
   priority: 75,
   severity: 'medium',
@@ -161,7 +161,7 @@ export const EXAM_ID: PIIPattern = {
  */
 export const EXAM_REGISTRATION_NUMBER: PIIPattern = {
   type: 'EXAM_REGISTRATION_NUMBER',
-  regex: /\bEXAM[-\s]?(\d{4}[-]\d{4})\b/gi,
+  regex: /\bEXAM[\-\s]?(\d{4}[-]\d{4})\b/gi,
   placeholder: '[EXAM_REG_{n}]',
   priority: 80,
   severity: 'high',
@@ -173,7 +173,7 @@ export const EXAM_REGISTRATION_NUMBER: PIIPattern = {
  */
 export const HOUSING_ASSIGNMENT: PIIPattern = {
   type: 'HOUSING_ASSIGNMENT',
-  regex: /\b(?:DORM|ROOM|HOUSING)[-\s]?(?:NO|NUM(?:BER)?|ASSIGNMENT)?[-\s]?[:#]?\s*([A-Z0-9]{4,10})\b/gi,
+  regex: /\b(?:DORM|ROOM|HOUSING)[\-\s]?(?:NO|NUM(?:BER)?|ASSIGNMENT)?[\-\s]?[:#]?\s*([A-Z0-9]{4,10})\b/gi,
   placeholder: '[HOUSING_{n}]',
   priority: 75,
   severity: 'medium',
@@ -188,7 +188,7 @@ export const HOUSING_ASSIGNMENT: PIIPattern = {
  */
 export const MEAL_PLAN_ID: PIIPattern = {
   type: 'MEAL_PLAN_ID',
-  regex: /\b(?:MEAL[-\s]?PLAN|DINING)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:MEAL[\-\s]?PLAN|DINING)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[MEAL_{n}]',
   priority: 70,
   severity: 'medium',
@@ -200,7 +200,7 @@ export const MEAL_PLAN_ID: PIIPattern = {
  */
 export const PARKING_PERMIT: PIIPattern = {
   type: 'PARKING_PERMIT',
-  regex: /\b(?:PARKING)[-\s]?(?:PERMIT|PASS|DECAL)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:PARKING)[\-\s]?(?:PERMIT|PASS|DECAL)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[PARKING_{n}]',
   priority: 70,
   severity: 'low',
@@ -212,7 +212,7 @@ export const PARKING_PERMIT: PIIPattern = {
  */
 export const SCHOLARSHIP_ID: PIIPattern = {
   type: 'SCHOLARSHIP_ID',
-  regex: /\b(?:SCHOLARSHIP|GRANT|AWARD)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:SCHOLARSHIP|GRANT|AWARD)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[SCHOLARSHIP_{n}]',
   priority: 80,
   severity: 'high',
@@ -227,7 +227,7 @@ export const SCHOLARSHIP_ID: PIIPattern = {
  */
 export const GRADUATION_YEAR: PIIPattern = {
   type: 'GRADUATION_YEAR',
-  regex: /\b(?:CLASS[-\s]?OF|GRADUATING[-\s]?CLASS|GRAD(?:UATION)?[-\s]?YEAR)[-\s]?[:#]?\s*(['']?\d{2}|[12]\d{3})\b/gi,
+  regex: /\b(?:CLASS[\-\s]?OF|GRADUATING[\-\s]?CLASS|GRAD(?:UATION)?[\-\s]?YEAR)[\-\s]?[:#]?\s*(['']?\d{2}|[12]\d{3})\b/gi,
   placeholder: '[GRAD_YEAR_{n}]',
   priority: 65,
   severity: 'low',
@@ -239,7 +239,7 @@ export const GRADUATION_YEAR: PIIPattern = {
  */
 export const APPLICATION_ID: PIIPattern = {
   type: 'APPLICATION_ID',
-  regex: /\b(?:APPLICATION|ADMISSION|APPLICANT)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
+  regex: /\b(?:APPLICATION|ADMISSION|APPLICANT)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
   placeholder: '[APPLICATION_{n}]',
   priority: 85,
   severity: 'high',
@@ -254,7 +254,7 @@ export const APPLICATION_ID: PIIPattern = {
  */
 export const ALUMNI_ID: PIIPattern = {
   type: 'ALUMNI_ID',
-  regex: /\b(?:ALUMNI|ALUMNUS|ALUMNA)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:ALUMNI|ALUMNUS|ALUMNA)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[ALUMNI_{n}]',
   priority: 75,
   severity: 'medium',
@@ -266,7 +266,7 @@ export const ALUMNI_ID: PIIPattern = {
  */
 export const RESEARCH_GRANT: PIIPattern = {
   type: 'RESEARCH_GRANT',
-  regex: /\b(?:GRANT|RESEARCH|FUNDING)[-\s]?(?:NO|NUM(?:BER)?|ID|REF)?[-\s]?[:#]?\s*([A-Z]{2,4}[-]?\d{6,10})\b/gi,
+  regex: /\b(?:GRANT|RESEARCH|FUNDING)[\-\s]?(?:NO|NUM(?:BER)?|ID|REF)?[\-\s]?[:#]?\s*([A-Z]{2,4}[-]?\d{6,10})\b/gi,
   placeholder: '[GRANT_{n}]',
   priority: 75,
   severity: 'medium',
@@ -281,7 +281,7 @@ export const RESEARCH_GRANT: PIIPattern = {
  */
 export const DEPARTMENT_CODE: PIIPattern = {
   type: 'DEPARTMENT_CODE',
-  regex: /\b(?:DEPT|DEPARTMENT)[-\s]?(?:CODE)?[-\s]?[:#]?\s*([A-Z]{3,6})\b/g,
+  regex: /\b(?:DEPT|DEPARTMENT)[\-\s]?(?:CODE)?[\-\s]?[:#]?\s*([A-Z]{3,6})\b/g,
   placeholder: '[DEPT_{n}]',
   priority: 55,
   severity: 'low',

--- a/packages/core/src/patterns/industries/emergency-services.ts
+++ b/packages/core/src/patterns/industries/emergency-services.ts
@@ -14,7 +14,7 @@ import { PIIPattern } from '../../types';
  */
 export const EMERGENCY_CALL_REF: PIIPattern = {
   type: 'EMERGENCY_CALL_REF',
-  regex: /\b(?:EMERGENCY|INCIDENT|CALL|CAD|DISPATCH|EVENT)[-\s]?(?:REF|NO|NUM|NUMBER|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:EMERGENCY|INCIDENT|CALL|CAD|DISPATCH|EVENT)[\-\s]?(?:REF|NO|NUM|NUMBER|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[EMERGENCY_REF_{n}]',
   priority: 95,
   severity: 'high',
@@ -30,7 +30,7 @@ export const EMERGENCY_CALL_REF: PIIPattern = {
  */
 export const POLICE_REPORT_NUMBER: PIIPattern = {
   type: 'POLICE_REPORT_NUMBER',
-  regex: /\b(?:POLICE|PR|RPT|REPORT|CASE)[-\s\u00A0]*(?:NO|NUM|NUMBER|ID)?[-\s\u00A0.:#]*((?:[A-Z]{2,4}[\s\u00A0./-]?\d{2,4}[\s\u00A0./-]?\d{4,10})|\d{4}[\s\u00A0./-]?\d{5,10})\b/gi,
+  regex: /\b(?:POLICE|PR|RPT|REPORT|CASE)[\-\s\u00A0]*(?:NO|NUM|NUMBER|ID)?[\-\s\u00A0.:#]*((?:[A-Z]{2,4}[\s\u00A0./-]?\d{2,4}[\s\u00A0./-]?\d{4,10})|\d{4}[\s\u00A0./-]?\d{5,10})\b/gi,
   placeholder: '[POLICE_RPT_{n}]',
   priority: 95,
   severity: 'high',
@@ -46,7 +46,7 @@ export const POLICE_REPORT_NUMBER: PIIPattern = {
  */
 export const FIRE_INCIDENT_NUMBER: PIIPattern = {
   type: 'FIRE_INCIDENT_NUMBER',
-  regex: /\b(?:FIRE|FI|FD)[-\s\u00A0]*(?:INCIDENT|INC|NO|NUM|NUMBER|ID)?[-\s\u00A0.:#]*((?:[A-Z]{2,4}[\s\u00A0./-]?\d{2,4}[\s\u00A0./-]?\d{4,10})|\d{4}[\s\u00A0./-]?\d{4,8})\b/gi,
+  regex: /\b(?:FIRE|FI|FD)[\-\s\u00A0]*(?:INCIDENT|INC|NO|NUM|NUMBER|ID)?[\-\s\u00A0.:#]*((?:[A-Z]{2,4}[\s\u00A0./-]?\d{2,4}[\s\u00A0./-]?\d{4,10})|\d{4}[\s\u00A0./-]?\d{4,8})\b/gi,
   placeholder: '[FIRE_INC_{n}]',
   priority: 95,
   severity: 'high',
@@ -62,7 +62,7 @@ export const FIRE_INCIDENT_NUMBER: PIIPattern = {
  */
 export const AMBULANCE_CALL_ID: PIIPattern = {
   type: 'AMBULANCE_CALL_ID',
-  regex: /\b(?:AMBULANCE|AMB|EMS|PARAMEDIC)[-\s]?(?:CALL|ID|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:AMBULANCE|AMB|EMS|PARAMEDIC)[\-\s]?(?:CALL|ID|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[AMB_CALL_{n}]',
   priority: 90,
   severity: 'high',
@@ -78,7 +78,7 @@ export const AMBULANCE_CALL_ID: PIIPattern = {
  */
 export const PARAMEDIC_CERTIFICATION: PIIPattern = {
   type: 'PARAMEDIC_CERTIFICATION',
-  regex: /\b(?:NREMT|EMT|PARAMEDIC)[-\s]?(?:P|B|A|I)?[-\s]?(?:CERT|LICENSE|LIC)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:NREMT|EMT|PARAMEDIC)[\-\s]?(?:P|B|A|I)?[\-\s]?(?:CERT|LICENSE|LIC)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[PARAMEDIC_CERT_{n}]',
   priority: 85,
   severity: 'medium',
@@ -95,7 +95,7 @@ export const PARAMEDIC_CERTIFICATION: PIIPattern = {
  */
 export const EMERGENCY_SHELTER_ID: PIIPattern = {
   type: 'EMERGENCY_SHELTER_ID',
-  regex: /\b(?:SHELTER|EVACUATION|REFUGE)[-\s]?(?:REG|ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{5,12})\b/gi,
+  regex: /\b(?:SHELTER|EVACUATION|REFUGE)[\-\s]?(?:REG|ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{5,12})\b/gi,
   placeholder: '[SHELTER_ID_{n}]',
   priority: 90,
   severity: 'high',
@@ -112,7 +112,7 @@ export const EMERGENCY_SHELTER_ID: PIIPattern = {
  */
 export const DISASTER_VICTIM_ID: PIIPattern = {
   type: 'DISASTER_VICTIM_ID',
-  regex: /\b(?:DVI|VICTIM)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*(\d{4}[-\s]?\d{4,8})\b/gi,
+  regex: /\b(?:DVI|VICTIM)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*(\d{4}[\-\s]?\d{4,8})\b/gi,
   placeholder: '[DVI_{n}]',
   priority: 95,
   severity: 'high',
@@ -128,7 +128,7 @@ export const DISASTER_VICTIM_ID: PIIPattern = {
  */
 export const SEARCH_RESCUE_MISSION_ID: PIIPattern = {
   type: 'SEARCH_RESCUE_MISSION_ID',
-  regex: /\b(?:SAR|SEARCH|RESCUE|MISSION)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:SAR|SEARCH|RESCUE|MISSION)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[SAR_MISSION_{n}]',
   priority: 90,
   severity: 'high',
@@ -144,7 +144,7 @@ export const SEARCH_RESCUE_MISSION_ID: PIIPattern = {
  */
 export const EMERGENCY_MEDICAL_INCIDENT: PIIPattern = {
   type: 'EMERGENCY_MEDICAL_INCIDENT',
-  regex: /\b(?:MEDICAL|MED|MI)[-\s]?(?:INCIDENT|INC|EMERGENCY|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:MEDICAL|MED|MI)[\-\s]?(?:INCIDENT|INC|EMERGENCY|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[MED_INC_{n}]',
   priority: 90,
   severity: 'high',
@@ -160,7 +160,7 @@ export const EMERGENCY_MEDICAL_INCIDENT: PIIPattern = {
  */
 export const FIREFIGHTER_BADGE: PIIPattern = {
   type: 'FIREFIGHTER_BADGE',
-  regex: /\b(?:BADGE|FF|FIREFIGHTER)[-\s]?(?:NO|NUM|NUMBER|ID)?[-\s]?[:#]?\s*(\d{3,6})\b/gi,
+  regex: /\b(?:BADGE|FF|FIREFIGHTER)[\-\s]?(?:NO|NUM|NUMBER|ID)?[\-\s]?[:#]?\s*(\d{3,6})\b/gi,
   placeholder: '[FF_BADGE_{n}]',
   priority: 80,
   severity: 'medium',
@@ -176,7 +176,7 @@ export const FIREFIGHTER_BADGE: PIIPattern = {
  */
 export const POLICE_BADGE: PIIPattern = {
   type: 'POLICE_BADGE',
-  regex: /\b(?:BADGE|SHIELD|OFFICER)[-\s]?(?:NO|NUM|NUMBER|ID)?[-\s]?[:#]?\s*(\d{3,6})\b/gi,
+  regex: /\b(?:BADGE|SHIELD|OFFICER)[\-\s]?(?:NO|NUM|NUMBER|ID)?[\-\s]?[:#]?\s*(\d{3,6})\b/gi,
   placeholder: '[POLICE_BADGE_{n}]',
   priority: 80,
   severity: 'medium',
@@ -192,7 +192,7 @@ export const POLICE_BADGE: PIIPattern = {
  */
 export const MISSING_PERSON_CASE: PIIPattern = {
   type: 'MISSING_PERSON_CASE',
-  regex: /\b(?:MISSING|MP|AMBER)[-\s]?(?:PERSON|CASE|ALERT)?[-\s]?(?:NO|NUMBER|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:MISSING|MP|AMBER)[\-\s]?(?:PERSON|CASE|ALERT)?[\-\s]?(?:NO|NUMBER|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[MISSING_CASE_{n}]',
   priority: 95,
   severity: 'high',
@@ -208,7 +208,7 @@ export const MISSING_PERSON_CASE: PIIPattern = {
  */
 export const DISPATCHER_ID: PIIPattern = {
   type: 'DISPATCHER_ID',
-  regex: /\b(?:DISPATCHER|DISP)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{3,8})\b/gi,
+  regex: /\b(?:DISPATCHER|DISP)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{3,8})\b/gi,
   placeholder: '[DISPATCHER_{n}]',
   priority: 80,
   severity: 'medium',
@@ -224,7 +224,7 @@ export const DISPATCHER_ID: PIIPattern = {
  */
 export const HAZMAT_INCIDENT: PIIPattern = {
   type: 'HAZMAT_INCIDENT',
-  regex: /\b(?:HAZMAT|HM)[-\s]?(?:INCIDENT|INC|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:HAZMAT|HM)[\-\s]?(?:INCIDENT|INC|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[HAZMAT_{n}]',
   priority: 90,
   severity: 'high',

--- a/packages/core/src/patterns/industries/environmental.ts
+++ b/packages/core/src/patterns/industries/environmental.ts
@@ -11,7 +11,7 @@ import type { PIIPattern } from '../../types';
  */
 export const EPA_ID_NUMBER: PIIPattern = {
   type: 'EPA_ID_NUMBER',
-  regex: /\bEPA[-\s]?(?:ID|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z]{2}[A-Z0-9]{9})\b/gi,
+  regex: /\bEPA[\-\s]?(?:ID|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z]{2}[A-Z0-9]{9})\b/gi,
   placeholder: '[EPA_ID_{n}]',
   priority: 85,
   severity: 'medium',
@@ -34,7 +34,7 @@ export const EPA_ID_NUMBER: PIIPattern = {
  */
 export const NPDES_PERMIT: PIIPattern = {
   type: 'NPDES_PERMIT',
-  regex: /\bNPDES[-\s]?(?:PERMIT|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z]{2}[A-Z0-9]{7,9})\b/gi,
+  regex: /\bNPDES[\-\s]?(?:PERMIT|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z]{2}[A-Z0-9]{7,9})\b/gi,
   placeholder: '[NPDES_{n}]',
   priority: 85,
   severity: 'medium',
@@ -50,7 +50,7 @@ export const NPDES_PERMIT: PIIPattern = {
  */
 export const HAZARDOUS_WASTE_MANIFEST: PIIPattern = {
   type: 'HAZARDOUS_WASTE_MANIFEST',
-  regex: /\b(?:MANIFEST|WASTE)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{9})\b/gi,
+  regex: /\b(?:MANIFEST|WASTE)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{9})\b/gi,
   placeholder: '[MANIFEST_{n}]',
   priority: 80,
   severity: 'medium',
@@ -68,7 +68,7 @@ export const HAZARDOUS_WASTE_MANIFEST: PIIPattern = {
  */
 export const AIR_QUALITY_PERMIT: PIIPattern = {
   type: 'AIR_QUALITY_PERMIT',
-  regex: /\b(?:AIR|EMISSION)[-\s]?PERMIT[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:AIR|EMISSION)[\-\s]?PERMIT[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[AIR_PERMIT_{n}]',
   priority: 80,
   severity: 'low',
@@ -84,7 +84,7 @@ export const AIR_QUALITY_PERMIT: PIIPattern = {
  */
 export const WATER_QUALITY_CERTIFICATE: PIIPattern = {
   type: 'WATER_QUALITY_CERTIFICATE',
-  regex: /\bWATER[-\s]?(?:QUALITY|CERT(?:IFICATE)?)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\bWATER[\-\s]?(?:QUALITY|CERT(?:IFICATE)?)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[WATER_CERT_{n}]',
   priority: 80,
   severity: 'low',
@@ -100,7 +100,7 @@ export const WATER_QUALITY_CERTIFICATE: PIIPattern = {
  */
 export const STORM_WATER_PERMIT: PIIPattern = {
   type: 'STORM_WATER_PERMIT',
-  regex: /\bSTORM\s?WATER[-\s]?PERMIT[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z]{2}[A-Z0-9]{6,10})\b/gi,
+  regex: /\bSTORM\s?WATER[\-\s]?PERMIT[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z]{2}[A-Z0-9]{6,10})\b/gi,
   placeholder: '[STORM_PERMIT_{n}]',
   priority: 80,
   severity: 'low',
@@ -116,7 +116,7 @@ export const STORM_WATER_PERMIT: PIIPattern = {
  */
 export const UST_ID: PIIPattern = {
   type: 'UST_ID',
-  regex: /\bUST[-\s]?(?:ID|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\bUST[\-\s]?(?:ID|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[UST_{n}]',
   priority: 80,
   severity: 'medium',
@@ -132,7 +132,7 @@ export const UST_ID: PIIPattern = {
  */
 export const FACILITY_ID: PIIPattern = {
   type: 'FACILITY_ID',
-  regex: /\bFACILITY[-\s]?ID[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\bFACILITY[\-\s]?ID[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[FACILITY_{n}]',
   priority: 75,
   severity: 'low',
@@ -148,7 +148,7 @@ export const FACILITY_ID: PIIPattern = {
  */
 export const TRI_FACILITY_ID: PIIPattern = {
   type: 'TRI_FACILITY_ID',
-  regex: /\bTRI[-\s]?(?:FACILITY|ID)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{11})\b/gi,
+  regex: /\bTRI[\-\s]?(?:FACILITY|ID)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{11})\b/gi,
   placeholder: '[TRI_FAC_{n}]',
   priority: 85,
   severity: 'low',
@@ -166,7 +166,7 @@ export const TRI_FACILITY_ID: PIIPattern = {
  */
 export const SPILL_REPORT_NUMBER: PIIPattern = {
   type: 'SPILL_REPORT_NUMBER',
-  regex: /\bSPILL[-\s]?(?:REPORT|NO|NUM|NUMBER)[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\bSPILL[\-\s]?(?:REPORT|NO|NUM|NUMBER)[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[SPILL_{n}]',
   priority: 80,
   severity: 'medium',
@@ -182,7 +182,7 @@ export const SPILL_REPORT_NUMBER: PIIPattern = {
  */
 export const REMEDIATION_SITE_ID: PIIPattern = {
   type: 'REMEDIATION_SITE_ID',
-  regex: /\b(?:REMEDIATION|CLEANUP)[-\s]?SITE[-\s]?(?:ID|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:REMEDIATION|CLEANUP)[\-\s]?SITE[\-\s]?(?:ID|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[REMEDIATION_{n}]',
   priority: 80,
   severity: 'low',
@@ -198,7 +198,7 @@ export const REMEDIATION_SITE_ID: PIIPattern = {
  */
 export const ENVIRONMENTAL_CERTIFICATE: PIIPattern = {
   type: 'ENVIRONMENTAL_CERTIFICATE',
-  regex: /\bENVIRONMENTAL[-\s]?(?:CERT(?:IFICATE)?|COMPLIANCE)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\bENVIRONMENTAL[\-\s]?(?:CERT(?:IFICATE)?|COMPLIANCE)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[ENV_CERT_{n}]',
   priority: 75,
   severity: 'low',

--- a/packages/core/src/patterns/industries/financial.ts
+++ b/packages/core/src/patterns/industries/financial.ts
@@ -19,7 +19,7 @@ export const SWIFT_BIC: PIIPattern = {
   description: 'SWIFT/BIC codes for international transfers',
   validator: (value: string, context: string) => {
     // Normalize separators (though SWIFT codes typically don't have them)
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '').toUpperCase();
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '').toUpperCase();
     
     // Must be in financial context
     const financialContext = /swift|bic|bank|transfer|wire|international|payment/i.test(context);
@@ -39,7 +39,7 @@ export const SWIFT_BIC: PIIPattern = {
  */
 export const TRANSACTION_ID: PIIPattern = {
   type: 'TRANSACTION_ID',
-  regex: /\b(?:TXN|TX|TRANS(?:ACTION)?)[-\s]?(?:ID|NO|NUM(?:BER)?|REF)?[-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
+  regex: /\b(?:TXN|TX|TRANS(?:ACTION)?)[\-\s]?(?:ID|NO|NUM(?:BER)?|REF)?[\-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
   placeholder: '[TXN_{n}]',
   priority: 80,
   severity: 'medium',
@@ -51,7 +51,7 @@ export const TRANSACTION_ID: PIIPattern = {
  */
 export const INVESTMENT_ACCOUNT: PIIPattern = {
   type: 'INVESTMENT_ACCOUNT',
-  regex: /\b(?:ISA|SIPP|INV(?:ESTMENT)?|PENSION|401K|IRA)[-\s\u00A0]*(?:ACCOUNT|ACCT|A\/C)?[-\s\u00A0]*(?:NO|NUM(?:BER)?)?[-\s\u00A0.:#]*([A-Z0-9](?:[A-Z0-9][\s\u00A0./-]?){5,18}[A-Z0-9])\b/gi,
+  regex: /\b(?:ISA|SIPP|INV(?:ESTMENT)?|PENSION|401K|IRA)[\-\s\u00A0]*(?:ACCOUNT|ACCT|A\/C)?[\-\s\u00A0]*(?:NO|NUM(?:BER)?)?[\-\s\u00A0.:#]*([A-Z0-9](?:[A-Z0-9][\s\u00A0./-]?){5,18}[A-Z0-9])\b/gi,
   placeholder: '[INV_ACCT_{n}]',
   priority: 85,
   severity: 'high',
@@ -70,7 +70,7 @@ export const INVESTMENT_ACCOUNT: PIIPattern = {
  */
 export const WIRE_TRANSFER_REF: PIIPattern = {
   type: 'WIRE_TRANSFER_REF',
-  regex: /\b(?:WIRE|TRANSFER|REMITTANCE)[-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?|ID)?[-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
+  regex: /\b(?:WIRE|TRANSFER|REMITTANCE)[\-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
   placeholder: '[WIRE_{n}]',
   priority: 85,
   severity: 'high',
@@ -82,7 +82,7 @@ export const WIRE_TRANSFER_REF: PIIPattern = {
  */
 export const DD_MANDATE: PIIPattern = {
   type: 'DD_MANDATE',
-  regex: /\b(?:DD|DIRECT[-\s]?DEBIT)[-\s]?(?:MANDATE|REF(?:ERENCE)?|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,18})\b/gi,
+  regex: /\b(?:DD|DIRECT[\-\s]?DEBIT)[\-\s]?(?:MANDATE|REF(?:ERENCE)?|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,18})\b/gi,
   placeholder: '[DD_MANDATE_{n}]',
   priority: 80,
   severity: 'high',
@@ -94,7 +94,7 @@ export const DD_MANDATE: PIIPattern = {
  */
 export const CHEQUE_NUMBER: PIIPattern = {
   type: 'CHEQUE_NUMBER',
-  regex: /\b(?:CHE(?:QUE|CK))[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*(\d{6,10})\b/gi,
+  regex: /\b(?:CHE(?:QUE|CK))[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*(\d{6,10})\b/gi,
   placeholder: '[CHEQUE_{n}]',
   priority: 75,
   severity: 'medium',
@@ -109,7 +109,7 @@ export const CHEQUE_NUMBER: PIIPattern = {
  */
 export const TRADING_ACCOUNT: PIIPattern = {
   type: 'TRADING_ACCOUNT',
-  regex: /\b(?:TRADING|BROKERAGE|STOCK)[-\s]?(?:ACCOUNT|ACCT|A\/C)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
+  regex: /\b(?:TRADING|BROKERAGE|STOCK)[\-\s]?(?:ACCOUNT|ACCT|A\/C)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
   placeholder: '[TRADE_ACCT_{n}]',
   priority: 85,
   severity: 'high',
@@ -121,7 +121,7 @@ export const TRADING_ACCOUNT: PIIPattern = {
  */
 export const LOAN_ACCOUNT: PIIPattern = {
   type: 'LOAN_ACCOUNT',
-  regex: /\b(?:LOAN|MORTGAGE|CREDIT)[-\s]?(?:ACCOUNT|ACCT|A\/C)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
+  regex: /\b(?:LOAN|MORTGAGE|CREDIT)[\-\s]?(?:ACCOUNT|ACCT|A\/C)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
   placeholder: '[LOAN_{n}]',
   priority: 85,
   severity: 'high',
@@ -239,7 +239,7 @@ export const CARDANO_ADDRESS: PIIPattern = {
  */
 export const CRYPTO_TX_HASH: PIIPattern = {
   type: 'CRYPTO_TX_HASH',
-  regex: /\b(?:TX|TXID|TRANSACTION[-\s]?HASH)[:\s]+([a-fA-F0-9]{64})\b/gi,
+  regex: /\b(?:TX|TXID|TRANSACTION[\-\s]?HASH)[:\s]+([a-fA-F0-9]{64})\b/gi,
   placeholder: '[CRYPTO_TX_{n}]',
   priority: 85,
   severity: 'high',
@@ -336,7 +336,7 @@ export const STOCK_TRADE: PIIPattern = {
  */
 export const WIRE_TRANSFER_DETAILS: PIIPattern = {
   type: 'WIRE_TRANSFER_DETAILS',
-  regex: /\b(?:WIRE\s+TO|TRANSFER\s+TO|BENEFICIARY)[:\s]+([A-Z0-9\s,.-]{20,100})/gi,
+  regex: /\b(?:WIRE\s+TO|TRANSFER\s+TO|BENEFICIARY)[:\s]+([A-Z0-9\s,.\-]{20,100})/gi,
   placeholder: '[WIRE_DETAILS_{n}]',
   priority: 90,
   severity: 'high',
@@ -387,7 +387,7 @@ export const SUBSCRIPTION_ID: PIIPattern = {
  */
 export const STATEMENT_REF: PIIPattern = {
   type: 'STATEMENT_REF',
-  regex: /\b(?:STATEMENT|STMT)[-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:STATEMENT|STMT)[\-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[STMT_{n}]',
   priority: 75,
   severity: 'medium',
@@ -399,7 +399,7 @@ export const STATEMENT_REF: PIIPattern = {
  */
 export const STANDING_ORDER_REF: PIIPattern = {
   type: 'STANDING_ORDER_REF',
-  regex: /\b(?:STANDING[-\s]?ORDER|SO)[-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:STANDING[\-\s]?ORDER|SO)[\-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[SO_{n}]',
   priority: 75,
   severity: 'medium',
@@ -411,7 +411,7 @@ export const STANDING_ORDER_REF: PIIPattern = {
  */
 export const PAYMENT_REFERENCE: PIIPattern = {
   type: 'PAYMENT_REFERENCE',
-  regex: /\b(?:PAYMENT|PAY)[-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?|ID)?[-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
+  regex: /\b(?:PAYMENT|PAY)[\-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
   placeholder: '[PAY_REF_{n}]',
   priority: 75,
   severity: 'medium',
@@ -423,7 +423,7 @@ export const PAYMENT_REFERENCE: PIIPattern = {
  */
 export const CARD_AUTH_CODE: PIIPattern = {
   type: 'CARD_AUTH_CODE',
-  regex: /\b(?:AUTH(?:ORIZATION)?|APPROVAL)[-\s]?(?:CODE|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:AUTH(?:ORIZATION)?|APPROVAL)[\-\s]?(?:CODE|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[AUTH_{n}]',
   priority: 80,
   severity: 'high',
@@ -438,7 +438,7 @@ export const CARD_AUTH_CODE: PIIPattern = {
  */
 export const MERCHANT_ID: PIIPattern = {
   type: 'MERCHANT_ID',
-  regex: /\b(?:MERCHANT|MID)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
+  regex: /\b(?:MERCHANT|MID)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
   placeholder: '[MERCHANT_{n}]',
   priority: 75,
   severity: 'medium',
@@ -453,7 +453,7 @@ export const MERCHANT_ID: PIIPattern = {
  */
 export const TERMINAL_ID: PIIPattern = {
   type: 'TERMINAL_ID',
-  regex: /\b(?:TERMINAL|TID|POS)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
+  regex: /\b(?:TERMINAL|TID|POS)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
   placeholder: '[TERMINAL_{n}]',
   priority: 75,
   severity: 'medium',
@@ -469,14 +469,14 @@ export const TERMINAL_ID: PIIPattern = {
  */
 export const UK_BANK_ACCOUNT_IBAN: PIIPattern = {
   type: 'UK_BANK_ACCOUNT_IBAN',
-  regex: /\b(GB\d{2}[\s\u00A0.-]?[A-Z]{4}[\s\u00A0.-]?\d{14})\b/gi,
+  regex: /\b(GB\d{2}[\s\u00A0.\-]?[A-Z]{4}[\s\u00A0.\-]?\d{14})\b/gi,
   placeholder: '[UK_IBAN_{n}]',
   priority: 95,
   severity: 'high',
   description: 'UK bank account numbers in IBAN format',
   validator: (value: string, context: string) => {
     // Normalize separators
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '').toUpperCase();
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '').toUpperCase();
     
     // Must start with GB and be exactly 22 characters
     if (!cleaned.startsWith('GB') || cleaned.length !== 22) {
@@ -517,7 +517,7 @@ export const UK_SORT_CODE_ACCOUNT: PIIPattern = {
   description: 'UK sort code and account number combination',
   validator: (value: string, context: string) => {
     // Normalize separators
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
     
     // Must be exactly 14 digits (6 for sort code + 8 for account)
     if (!/^\d{14}$/.test(cleaned)) {

--- a/packages/core/src/patterns/industries/gaming.ts
+++ b/packages/core/src/patterns/industries/gaming.ts
@@ -37,7 +37,7 @@ export const RIOT_ID: PIIPattern = {
  */
 export const TWITCH_USERNAME: PIIPattern = {
   type: 'TWITCH_USERNAME',
-  regex: /\bTWITCH[-\s]?(?:USER|NAME|ID)?[-\s]?[:#]?\s*([a-zA-Z0-9_]{4,25})\b/gi,
+  regex: /\bTWITCH[\-\s]?(?:USER|NAME|ID)?[\-\s]?[:#]?\s*([a-zA-Z0-9_]{4,25})\b/gi,
   placeholder: '[TWITCH_{n}]',
   priority: 75,
   severity: 'medium',
@@ -58,7 +58,7 @@ export const TWITCH_USERNAME: PIIPattern = {
  */
 export const ESPORTS_PLAYER_ID: PIIPattern = {
   type: 'ESPORTS_PLAYER_ID',
-  regex: /\b(?:PLAYER|COMPETITOR|PARTICIPANT)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:PLAYER|COMPETITOR|PARTICIPANT)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[PLAYER_ID_{n}]',
   priority: 75,
   severity: 'medium',
@@ -75,7 +75,7 @@ export const ESPORTS_PLAYER_ID: PIIPattern = {
  */
 export const TOURNAMENT_REGISTRATION_ID: PIIPattern = {
   type: 'TOURNAMENT_REGISTRATION_ID',
-  regex: /\b(?:TOURNAMENT|BRACKET|REGISTRATION|REG)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:TOURNAMENT|BRACKET|REGISTRATION|REG)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[TOURNEY_{n}]',
   priority: 75,
   severity: 'medium',
@@ -92,7 +92,7 @@ export const TOURNAMENT_REGISTRATION_ID: PIIPattern = {
  */
 export const ROBLOX_USER_ID: PIIPattern = {
   type: 'ROBLOX_USER_ID',
-  regex: /\bROBLOX[-\s]?(?:USER|ID)?[-\s]?[:#]?\s*(\d{1,12})\b/gi,
+  regex: /\bROBLOX[\-\s]?(?:USER|ID)?[\-\s]?[:#]?\s*(\d{1,12})\b/gi,
   placeholder: '[ROBLOX_{n}]',
   priority: 80,
   severity: 'medium',
@@ -137,7 +137,7 @@ export const MINECRAFT_UUID: PIIPattern = {
  */
 export const FORTNITE_ACCOUNT_ID: PIIPattern = {
   type: 'FORTNITE_ACCOUNT_ID',
-  regex: /\b(?:FORTNITE|FN)[-\s]?(?:ACCOUNT|USER|ID)?[-\s]?[:#]?\s*([a-f0-9]{32})\b/gi,
+  regex: /\b(?:FORTNITE|FN)[\-\s]?(?:ACCOUNT|USER|ID)?[\-\s]?[:#]?\s*([a-f0-9]{32})\b/gi,
   placeholder: '[FN_ID_{n}]',
   priority: 75,
   severity: 'medium',
@@ -184,7 +184,7 @@ export const COD_PLAYER_ID: PIIPattern = {
  */
 export const APEX_PLAYER_ID: PIIPattern = {
   type: 'APEX_PLAYER_ID',
-  regex: /\b(?:APEX|EA)[-\s]?(?:ID|PLAYER)?[-\s]?[:#]?\s*([A-Z0-9]{10,16})\b/gi,
+  regex: /\b(?:APEX|EA)[\-\s]?(?:ID|PLAYER)?[\-\s]?[:#]?\s*([A-Z0-9]{10,16})\b/gi,
   placeholder: '[APEX_ID_{n}]',
   priority: 70,
   severity: 'medium',
@@ -201,7 +201,7 @@ export const APEX_PLAYER_ID: PIIPattern = {
  */
 export const DOTA_FRIEND_ID: PIIPattern = {
   type: 'DOTA_FRIEND_ID',
-  regex: /\bDOTA[-\s]?(?:ID|FRIEND)?[-\s]?[:#]?\s*(\d{9,10})\b/gi,
+  regex: /\bDOTA[\-\s]?(?:ID|FRIEND)?[\-\s]?[:#]?\s*(\d{9,10})\b/gi,
   placeholder: '[DOTA_ID_{n}]',
   priority: 70,
   severity: 'medium',
@@ -222,7 +222,7 @@ export const DOTA_FRIEND_ID: PIIPattern = {
  */
 export const CSGO_FRIEND_CODE: PIIPattern = {
   type: 'CSGO_FRIEND_CODE',
-  regex: /\b(?:CS:?GO|COUNTER[- ]?STRIKE)[-\s]?(?:FRIEND[- ]?CODE|CODE)?[-\s]?[:#]?\s*([A-Z0-9]{5}-[A-Z0-9]{5})\b/gi,
+  regex: /\b(?:CS:?GO|COUNTER[- ]?STRIKE)[\-\s]?(?:FRIEND[- ]?CODE|CODE)?[\-\s]?[:#]?\s*([A-Z0-9]{5}-[A-Z0-9]{5})\b/gi,
   placeholder: '[CSGO_CODE_{n}]',
   priority: 75,
   severity: 'medium',

--- a/packages/core/src/patterns/industries/gig-economy.ts
+++ b/packages/core/src/patterns/industries/gig-economy.ts
@@ -12,7 +12,7 @@ import { PIIPattern } from '../../types';
  */
 export const UBER_TRIP_ID: PIIPattern = {
   type: 'UBER_TRIP_ID',
-  regex: /\bUBER[-\s]?(?:TRIP|RIDE)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{8,24})\b/gi,
+  regex: /\bUBER[\-\s]?(?:TRIP|RIDE)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{8,24})\b/gi,
   placeholder: '[UBER_TRIP_{n}]',
   priority: 85,
   severity: 'medium',
@@ -29,7 +29,7 @@ export const UBER_TRIP_ID: PIIPattern = {
  */
 export const LYFT_RIDE_ID: PIIPattern = {
   type: 'LYFT_RIDE_ID',
-  regex: /\bLYFT[-\s]?(?:RIDE|TRIP)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{8,24})\b/gi,
+  regex: /\bLYFT[\-\s]?(?:RIDE|TRIP)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{8,24})\b/gi,
   placeholder: '[LYFT_RIDE_{n}]',
   priority: 85,
   severity: 'medium',
@@ -46,7 +46,7 @@ export const LYFT_RIDE_ID: PIIPattern = {
  */
 export const DOORDASH_ORDER_ID: PIIPattern = {
   type: 'DOORDASH_ORDER_ID',
-  regex: /\b(?:DOORDASH|DD)[-\s]?(?:ORDER|DELIVERY)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,20})\b/gi,
+  regex: /\b(?:DOORDASH|DD)[\-\s]?(?:ORDER|DELIVERY)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,20})\b/gi,
   placeholder: '[DD_ORDER_{n}]',
   priority: 80,
   severity: 'medium',
@@ -63,7 +63,7 @@ export const DOORDASH_ORDER_ID: PIIPattern = {
  */
 export const UBEREATS_ORDER_ID: PIIPattern = {
   type: 'UBEREATS_ORDER_ID',
-  regex: /\bUBER[-\s]?EATS[-\s]?(?:ORDER|DELIVERY)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,20})\b/gi,
+  regex: /\bUBER[\-\s]?EATS[\-\s]?(?:ORDER|DELIVERY)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,20})\b/gi,
   placeholder: '[UE_ORDER_{n}]',
   priority: 80,
   severity: 'medium',
@@ -80,7 +80,7 @@ export const UBEREATS_ORDER_ID: PIIPattern = {
  */
 export const GRUBHUB_ORDER_ID: PIIPattern = {
   type: 'GRUBHUB_ORDER_ID',
-  regex: /\bGRUBHUB[-\s]?(?:ORDER)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,20})\b/gi,
+  regex: /\bGRUBHUB[\-\s]?(?:ORDER)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,20})\b/gi,
   placeholder: '[GH_ORDER_{n}]',
   priority: 80,
   severity: 'medium',
@@ -97,7 +97,7 @@ export const GRUBHUB_ORDER_ID: PIIPattern = {
  */
 export const AIRBNB_RESERVATION_ID: PIIPattern = {
   type: 'AIRBNB_RESERVATION_ID',
-  regex: /\bAIRBNB[-\s]?(?:RESERVATION|BOOKING|CONF(?:IRMATION)?)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{9,16})\b/gi,
+  regex: /\bAIRBNB[\-\s]?(?:RESERVATION|BOOKING|CONF(?:IRMATION)?)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{9,16})\b/gi,
   placeholder: '[AIRBNB_RES_{n}]',
   priority: 85,
   severity: 'medium',
@@ -114,7 +114,7 @@ export const AIRBNB_RESERVATION_ID: PIIPattern = {
  */
 export const INSTACART_ORDER_ID: PIIPattern = {
   type: 'INSTACART_ORDER_ID',
-  regex: /\bINSTACART[-\s]?(?:ORDER|DELIVERY)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,20})\b/gi,
+  regex: /\bINSTACART[\-\s]?(?:ORDER|DELIVERY)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,20})\b/gi,
   placeholder: '[IC_ORDER_{n}]',
   priority: 80,
   severity: 'medium',
@@ -131,7 +131,7 @@ export const INSTACART_ORDER_ID: PIIPattern = {
  */
 export const TASKRABBIT_TASK_ID: PIIPattern = {
   type: 'TASKRABBIT_TASK_ID',
-  regex: /\b(?:TASKRABBIT|TR)[-\s]?(?:TASK|JOB)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
+  regex: /\b(?:TASKRABBIT|TR)[\-\s]?(?:TASK|JOB)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
   placeholder: '[TR_TASK_{n}]',
   priority: 75,
   severity: 'medium',
@@ -148,7 +148,7 @@ export const TASKRABBIT_TASK_ID: PIIPattern = {
  */
 export const UPWORK_JOB_ID: PIIPattern = {
   type: 'UPWORK_JOB_ID',
-  regex: /\bUPWORK[-\s]?(?:JOB|CONTRACT|PROJECT)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
+  regex: /\bUPWORK[\-\s]?(?:JOB|CONTRACT|PROJECT)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
   placeholder: '[UW_JOB_{n}]',
   priority: 80,
   severity: 'medium',
@@ -165,7 +165,7 @@ export const UPWORK_JOB_ID: PIIPattern = {
  */
 export const FIVERR_ORDER_ID: PIIPattern = {
   type: 'FIVERR_ORDER_ID',
-  regex: /\bFIVERR[-\s]?(?:ORDER|GIG)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
+  regex: /\bFIVERR[\-\s]?(?:ORDER|GIG)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
   placeholder: '[FV_ORDER_{n}]',
   priority: 75,
   severity: 'medium',
@@ -182,7 +182,7 @@ export const FIVERR_ORDER_ID: PIIPattern = {
  */
 export const POSTMATES_DELIVERY_ID: PIIPattern = {
   type: 'POSTMATES_DELIVERY_ID',
-  regex: /\bPOSTMATES[-\s]?(?:DELIVERY|ORDER)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,20})\b/gi,
+  regex: /\bPOSTMATES[\-\s]?(?:DELIVERY|ORDER)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,20})\b/gi,
   placeholder: '[PM_DEL_{n}]',
   priority: 75,
   severity: 'medium',
@@ -199,7 +199,7 @@ export const POSTMATES_DELIVERY_ID: PIIPattern = {
  */
 export const GIG_PLATFORM_USER_ID: PIIPattern = {
   type: 'GIG_PLATFORM_USER_ID',
-  regex: /\b(?:DRIVER|DASHER|SHOPPER|TASKER|COURIER|RIDER)[-\s]?(?:ID|NO|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
+  regex: /\b(?:DRIVER|DASHER|SHOPPER|TASKER|COURIER|RIDER)[\-\s]?(?:ID|NO|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
   placeholder: '[GIG_USER_{n}]',
   priority: 70,
   severity: 'medium',
@@ -216,7 +216,7 @@ export const GIG_PLATFORM_USER_ID: PIIPattern = {
  */
 export const GIG_PLATFORM_ORDER_ID: PIIPattern = {
   type: 'GIG_PLATFORM_ORDER_ID',
-  regex: /\b(?:ORDER|TRIP|DELIVERY|BOOKING)[-\s]?[:#]\s*([A-Z0-9]{8,20})\b/gi,
+  regex: /\b(?:ORDER|TRIP|DELIVERY|BOOKING)[\-\s]?[:#]\s*([A-Z0-9]{8,20})\b/gi,
   placeholder: '[GIG_ORDER_{n}]',
   priority: 65,
   severity: 'medium',

--- a/packages/core/src/patterns/industries/healthcare.ts
+++ b/packages/core/src/patterns/industries/healthcare.ts
@@ -10,7 +10,7 @@ import { PIIPattern } from '../../types';
  */
 export const MEDICAL_RECORD_NUMBER: PIIPattern = {
   type: 'MEDICAL_RECORD_NUMBER',
-  regex: /\b(?:MR[N]?[-\s]?|MEDICAL[-\s]?REC(?:ORD)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*)([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:MR[N]?[\-\s]?|MEDICAL[\-\s]?REC(?:ORD)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*)([A-Z0-9]{6,12})\b/gi,
   placeholder: '[MRN_{n}]',
   priority: 85,
   severity: 'high',
@@ -22,7 +22,7 @@ export const MEDICAL_RECORD_NUMBER: PIIPattern = {
  */
 export const PATIENT_ID: PIIPattern = {
   type: 'PATIENT_ID',
-  regex: /\b(?:PATIENT[-\s]?(?:ID|NUM(?:BER)?|REF(?:ERENCE)?)[-\s]?[:#]?\s*)([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:PATIENT[\-\s]?(?:ID|NUM(?:BER)?|REF(?:ERENCE)?)[\-\s]?[:#]?\s*)([A-Z0-9]{6,12})\b/gi,
   placeholder: '[PATIENT_ID_{n}]',
   priority: 85,
   severity: 'high',
@@ -34,7 +34,7 @@ export const PATIENT_ID: PIIPattern = {
  */
 export const APPOINTMENT_REF: PIIPattern = {
   type: 'APPOINTMENT_REF',
-  regex: /\b(?:APT|APPT|APPOINTMENT)[-\s]?(?:REF|ID|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,10})\b/gi,
+  regex: /\b(?:APT|APPT|APPOINTMENT)[\-\s]?(?:REF|ID|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,10})\b/gi,
   placeholder: '[APT_{n}]',
   priority: 75,
   severity: 'medium',
@@ -67,7 +67,7 @@ export const ICD10_CODE: PIIPattern = {
  */
 export const CPT_CODE: PIIPattern = {
   type: 'CPT_CODE',
-  regex: /\b(?:CPT[-\s]?(?:CODE)?[-\s]?[:#]?\s*)?([0-9]{5})\b/g,
+  regex: /\b(?:CPT[\-\s]?(?:CODE)?[\-\s]?[:#]?\s*)?([0-9]{5})\b/g,
   placeholder: '[CPT_{n}]',
   priority: 70,
   severity: 'medium',
@@ -87,7 +87,7 @@ export const CPT_CODE: PIIPattern = {
  */
 export const PRESCRIPTION_NUMBER: PIIPattern = {
   type: 'PRESCRIPTION_NUMBER',
-  regex: /\b(?:RX|PRESC(?:RIPTION)?|SCRIPT)[-\s]?(?:NO|NUM(?:BER)?|REF|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:RX|PRESC(?:RIPTION)?|SCRIPT)[\-\s]?(?:NO|NUM(?:BER)?|REF|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[RX_{n}]',
   priority: 80,
   severity: 'high',
@@ -99,7 +99,7 @@ export const PRESCRIPTION_NUMBER: PIIPattern = {
  */
 export const HEALTH_INSURANCE_CLAIM: PIIPattern = {
   type: 'HEALTH_INSURANCE_CLAIM',
-  regex: /\b(?:CLAIM|CLM)[-\s]?(?:NO|NUM(?:BER)?|REF|ID)?[-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
+  regex: /\b(?:CLAIM|CLM)[\-\s]?(?:NO|NUM(?:BER)?|REF|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
   placeholder: '[CLAIM_{n}]',
   priority: 80,
   severity: 'high',
@@ -115,7 +115,7 @@ export const HEALTH_INSURANCE_CLAIM: PIIPattern = {
  */
 export const HEALTH_PLAN_NUMBER: PIIPattern = {
   type: 'HEALTH_PLAN_NUMBER',
-  regex: /\b(?:HEALTH[-\s]?PLAN|BENEFICIARY|MEMBER)[-\s]?(?:NO|NUM(?:BER)?|ID)?[-\s]?[:#]?\s*([A-Z0-9]{8,15})\b/gi,
+  regex: /\b(?:HEALTH[\-\s]?PLAN|BENEFICIARY|MEMBER)[\-\s]?(?:NO|NUM(?:BER)?|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{8,15})\b/gi,
   placeholder: '[HEALTH_PLAN_{n}]',
   priority: 85,
   severity: 'high',
@@ -127,7 +127,7 @@ export const HEALTH_PLAN_NUMBER: PIIPattern = {
  */
 export const MEDICAL_DEVICE_SERIAL: PIIPattern = {
   type: 'MEDICAL_DEVICE_SERIAL',
-  regex: /\b(?:DEVICE|IMPLANT|PACEMAKER|DEFIBRILLATOR)[-\s]?(?:SERIAL|SN|S\/N)[-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
+  regex: /\b(?:DEVICE|IMPLANT|PACEMAKER|DEFIBRILLATOR)[\-\s]?(?:SERIAL|SN|S\/N)[\-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
   placeholder: '[DEVICE_{n}]',
   priority: 75,
   severity: 'high',
@@ -139,7 +139,7 @@ export const MEDICAL_DEVICE_SERIAL: PIIPattern = {
  */
 export const LAB_TEST_ID: PIIPattern = {
   type: 'LAB_TEST_ID',
-  regex: /\b(?:LAB|TEST|SAMPLE)[-\s]?(?:ID|NUM(?:BER)?|REF)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:LAB|TEST|SAMPLE)[\-\s]?(?:ID|NUM(?:BER)?|REF)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[LAB_{n}]',
   priority: 75,
   severity: 'medium',
@@ -154,7 +154,7 @@ export const LAB_TEST_ID: PIIPattern = {
  */
 export const TRIAL_PARTICIPANT_ID: PIIPattern = {
   type: 'TRIAL_PARTICIPANT_ID',
-  regex: /\b(?:PARTICIPANT|SUBJECT|TRIAL)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z]{1,2}[-]?\d{4,6})\b/gi,
+  regex: /\b(?:PARTICIPANT|SUBJECT|TRIAL)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z]{1,2}[-]?\d{4,6})\b/gi,
   placeholder: '[TRIAL_PART_{n}]',
   priority: 85,
   severity: 'high',
@@ -166,7 +166,7 @@ export const TRIAL_PARTICIPANT_ID: PIIPattern = {
  */
 export const PROTOCOL_NUMBER: PIIPattern = {
   type: 'PROTOCOL_NUMBER',
-  regex: /\b(?:PROTOCOL|STUDY)[-\s]?(?:NO|NUM(?:BER)?|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:PROTOCOL|STUDY)[\-\s]?(?:NO|NUM(?:BER)?|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[PROTOCOL_{n}]',
   priority: 75,
   severity: 'medium',
@@ -196,7 +196,7 @@ export const GENETIC_MARKER: PIIPattern = {
  */
 export const BIOBANK_SAMPLE_ID: PIIPattern = {
   type: 'BIOBANK_SAMPLE_ID',
-  regex: /\b(?:BIOBANK|SAMPLE|SPECIMEN)[-\s]?(?:ID|NO)?[-\s]?[:#]?\s*([A-Z0-9]{8,15})\b/gi,
+  regex: /\b(?:BIOBANK|SAMPLE|SPECIMEN)[\-\s]?(?:ID|NO)?[\-\s]?[:#]?\s*([A-Z0-9]{8,15})\b/gi,
   placeholder: '[BIOBANK_{n}]',
   priority: 85,
   severity: 'high',
@@ -212,7 +212,7 @@ export const BIOBANK_SAMPLE_ID: PIIPattern = {
 export const PROVIDER_LICENSE: PIIPattern = {
   type: 'PROVIDER_LICENSE',
   regex:
-    /\b(?:MEDICAL|PHYSICIAN|DOCTOR|NURSE|PROVIDER)[-\s\u00A0]*(?:LICENSE|LICENCE|LIC)[-\s\u00A0]*(?:NO|NUM(?:BER)?)?[-\s\u00A0.:#]*((?:[A-Z0-9]{2,6}[\s\u00A0./-]?){1,3}[A-Z0-9]{2,6})\b/gi,
+    /\b(?:MEDICAL|PHYSICIAN|DOCTOR|NURSE|PROVIDER)[\-\s\u00A0]*(?:LICENSE|LICENCE|LIC)[\-\s\u00A0]*(?:NO|NUM(?:BER)?)?[\-\s\u00A0.:#]*((?:[A-Z0-9]{2,6}[\s\u00A0./-]?){1,3}[A-Z0-9]{2,6})\b/gi,
   placeholder: '[PROVIDER_LIC_{n}]',
   priority: 80,
   severity: 'high',
@@ -231,7 +231,7 @@ export const PROVIDER_LICENSE: PIIPattern = {
  */
 export const NPI_NUMBER: PIIPattern = {
   type: 'NPI_NUMBER',
-  regex: /\b(?:NPI[-\s\u00A0]*(?:NO|NUM(?:BER)?)?[-\s\u00A0.:#]*)?((?:\d[\s\u00A0.-]?){10})\b/g,
+  regex: /\b(?:NPI[\-\s\u00A0]*(?:NO|NUM(?:BER)?)?[\-\s\u00A0.:#]*)?((?:\d[\s\u00A0.\-]?){10})\b/g,
   placeholder: '[NPI_{n}]',
   priority: 85,
   severity: 'high',
@@ -266,7 +266,7 @@ export const NPI_NUMBER: PIIPattern = {
  */
 export const DEA_NUMBER: PIIPattern = {
   type: 'DEA_NUMBER',
-  regex: /\b(?:DEA[-\s\u00A0]*(?:NO|NUM(?:BER)?)?[-\s\u00A0.:#]*)?([A-Z]{2}(?:[\s\u00A0.-]?\d){7})\b/gi,
+  regex: /\b(?:DEA[\-\s\u00A0]*(?:NO|NUM(?:BER)?)?[\-\s\u00A0.:#]*)?([A-Z]{2}(?:[\s\u00A0.\-]?\d){7})\b/gi,
   placeholder: '[DEA_{n}]',
   priority: 90,
   severity: 'high',
@@ -296,7 +296,7 @@ export const DEA_NUMBER: PIIPattern = {
  */
 export const HOSPITAL_ACCOUNT: PIIPattern = {
   type: 'HOSPITAL_ACCOUNT',
-  regex: /\b(?:HOSPITAL|H|HAR)[-\s]?(?:ACCOUNT|ACCT|A\/C)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
+  regex: /\b(?:HOSPITAL|H|HAR)[\-\s]?(?:ACCOUNT|ACCT|A\/C)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
   placeholder: '[H_ACCT_{n}]',
   priority: 80,
   severity: 'high',
@@ -323,7 +323,7 @@ export const EMERGENCY_CONTACT_MARKER: PIIPattern = {
 export const BIOMETRIC_ID: PIIPattern = {
   type: 'BIOMETRIC_ID',
   regex:
-    /\b(?:FINGERPRINT|RETINAL?[-\s\u00A0]?SCAN|IRIS[-\s\u00A0]?SCAN|VOICE[-\s\u00A0]?PRINT|FACIAL[-\s\u00A0]?RECOGNITION|BIOMETRIC)[-\s\u00A0]?(?:ID|DATA|TEMPLATE|HASH)?[-\s\u00A0.:#]*([A-Z0-9][A-Z0-9._-]{7,39})\b/gi,
+    /\b(?:FINGERPRINT|RETINAL?[\-\s\u00A0]?SCAN|IRIS[\-\s\u00A0]?SCAN|VOICE[\-\s\u00A0]?PRINT|FACIAL[\-\s\u00A0]?RECOGNITION|BIOMETRIC)[\-\s\u00A0]?(?:ID|DATA|TEMPLATE|HASH)?[\-\s\u00A0.:#]*([A-Z0-9][A-Z0-9._-]{7,39})\b/gi,
   placeholder: '[BIOMETRIC_{n}]',
   priority: 95,
   severity: 'high',
@@ -381,7 +381,7 @@ export const DRUG_DOSAGE: PIIPattern = {
 export const MEDICAL_IMAGE_REF: PIIPattern = {
   type: 'MEDICAL_IMAGE_REF',
   regex:
-    /\b(?:X[-\s\u00A0]?RAY|MRI|CT[-\s\u00A0]?SCAN|PET[-\s\u00A0]?SCAN|ULTRASOUND|MAMMOGRAM)[-\s\u00A0]?(?:IMAGE|FILE|ID)?[-\s\u00A0.:#]*([A-Z0-9][A-Z0-9_.-]{5,23})\b/gi,
+    /\b(?:X[\-\s\u00A0]?RAY|MRI|CT[\-\s\u00A0]?SCAN|PET[\-\s\u00A0]?SCAN|ULTRASOUND|MAMMOGRAM)[\-\s\u00A0]?(?:IMAGE|FILE|ID)?[\-\s\u00A0.:#]*([A-Z0-9][A-Z0-9_.\-]{5,23})\b/gi,
   placeholder: '[IMAGE_{n}]',
   priority: 80,
   severity: 'high',
@@ -417,7 +417,7 @@ export const ALLERGY_INFO: PIIPattern = {
  */
 export const VACCINATION_ID: PIIPattern = {
   type: 'VACCINATION_ID',
-  regex: /\b(?:VACCINE|VACCINATION|IMMUNIZATION)[-\s]?(?:ID|RECORD|NO)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:VACCINE|VACCINATION|IMMUNIZATION)[\-\s]?(?:ID|RECORD|NO)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[VAX_{n}]',
   priority: 80,
   severity: 'high',
@@ -433,7 +433,7 @@ export const VACCINATION_ID: PIIPattern = {
  */
 export const CHI_NUMBER: PIIPattern = {
   type: 'CHI_NUMBER',
-  regex: /\b(?:CHI|community health index)[-\s]?(?:number|no)?[-\s]?[:#]?\s*(\d{6}[-\s]?\d{4})\b/gi,
+  regex: /\b(?:CHI|community health index)[\-\s]?(?:number|no)?[\-\s]?[:#]?\s*(\d{6}[\-\s]?\d{4})\b/gi,
   placeholder: '[CHI_{n}]',
   priority: 95,
   severity: 'high',
@@ -473,7 +473,7 @@ export const CHI_NUMBER: PIIPattern = {
  */
 export const EHIC_NUMBER: PIIPattern = {
   type: 'EHIC_NUMBER',
-  regex: /\b(?:EHIC|european health insurance|health card)[-\s]?(?:number|no)?[-\s]?[:#]?\s*([A-Z]{2}\s?\d{12,16})\b/gi,
+  regex: /\b(?:EHIC|european health insurance|health card)[\-\s]?(?:number|no)?[\-\s]?[:#]?\s*([A-Z]{2}\s?\d{12,16})\b/gi,
   placeholder: '[EHIC_{n}]',
   priority: 90,
   severity: 'high',

--- a/packages/core/src/patterns/industries/hospitality.ts
+++ b/packages/core/src/patterns/industries/hospitality.ts
@@ -12,7 +12,7 @@ import { PIIPattern } from '../../types';
  */
 export const AIRLINE_PNR: PIIPattern = {
   type: 'AIRLINE_PNR',
-  regex: /\b(?:PNR|BOOKING|CONFIRMATION)[-\s]?(?:NO|NUM|NUMBER|CODE)?[-\s]?[:#]?\s*([A-Z0-9]{6})\b/gi,
+  regex: /\b(?:PNR|BOOKING|CONFIRMATION)[\-\s]?(?:NO|NUM|NUMBER|CODE)?[\-\s]?[:#]?\s*([A-Z0-9]{6})\b/gi,
   placeholder: '[PNR_{n}]',
   priority: 85,
   severity: 'medium',
@@ -33,13 +33,13 @@ export const AIRLINE_PNR: PIIPattern = {
  */
 export const HOTEL_RESERVATION: PIIPattern = {
   type: 'HOTEL_RESERVATION',
-  regex: /\b(?:HOTEL|RESERVATION|CONF(?:IRMATION)?|BOOKING)[-\s]?(?:NO|NUM|NUMBER|CODE)?[-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
+  regex: /\b(?:HOTEL|RESERVATION|CONF(?:IRMATION)?|BOOKING)[\-\s]?(?:NO|NUM|NUMBER|CODE)?[\-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
   placeholder: '[HOTEL_RES_{n}]',
   priority: 80,
   severity: 'medium',
   description: 'Hotel reservation/confirmation number',
   validator: (_value: string, context: string) => {
-    return /hotel|reservation|booking|room|accommodation|stay|check[-\s]?in|lodging/i.test(context);
+    return /hotel|reservation|booking|room|accommodation|stay|check[\-\s]?in|lodging/i.test(context);
   }
 };
 
@@ -50,7 +50,7 @@ export const HOTEL_RESERVATION: PIIPattern = {
  */
 export const FREQUENT_FLYER_NUMBER: PIIPattern = {
   type: 'FREQUENT_FLYER_NUMBER',
-  regex: /\b(?:FREQUENT[- ]?FLYER|FF|MILEAGE|LOYALTY)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:FREQUENT[- ]?FLYER|FF|MILEAGE|LOYALTY)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[FF_NUM_{n}]',
   priority: 75,
   severity: 'medium',
@@ -67,7 +67,7 @@ export const FREQUENT_FLYER_NUMBER: PIIPattern = {
  */
 export const HOTEL_LOYALTY_NUMBER: PIIPattern = {
   type: 'HOTEL_LOYALTY_NUMBER',
-  regex: /\b(?:MEMBER|LOYALTY|REWARDS)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:MEMBER|LOYALTY|REWARDS)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[HOTEL_LOYALTY_{n}]',
   priority: 75,
   severity: 'medium',
@@ -84,7 +84,7 @@ export const HOTEL_LOYALTY_NUMBER: PIIPattern = {
  */
 export const CRUISE_BOOKING_NUMBER: PIIPattern = {
   type: 'CRUISE_BOOKING_NUMBER',
-  regex: /\b(?:CRUISE|BOOKING|RESERVATION)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:CRUISE|BOOKING|RESERVATION)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[CRUISE_{n}]',
   priority: 75,
   severity: 'medium',
@@ -101,7 +101,7 @@ export const CRUISE_BOOKING_NUMBER: PIIPattern = {
  */
 export const TRAVEL_AGENCY_BOOKING: PIIPattern = {
   type: 'TRAVEL_AGENCY_BOOKING',
-  regex: /\b(?:TRAVEL|AGENCY|BOOKING|TRIP)[-\s]?(?:REF|REFERENCE|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:TRAVEL|AGENCY|BOOKING|TRIP)[\-\s]?(?:REF|REFERENCE|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[TRAVEL_REF_{n}]',
   priority: 70,
   severity: 'medium',
@@ -118,7 +118,7 @@ export const TRAVEL_AGENCY_BOOKING: PIIPattern = {
  */
 export const RENTAL_CAR_CONFIRMATION: PIIPattern = {
   type: 'RENTAL_CAR_CONFIRMATION',
-  regex: /\b(?:RENTAL|CAR|VEHICLE)[-\s]?(?:CONF(?:IRMATION)?|RESERVATION|BOOKING)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:RENTAL|CAR|VEHICLE)[\-\s]?(?:CONF(?:IRMATION)?|RESERVATION|BOOKING)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[CAR_RENTAL_{n}]',
   priority: 75,
   severity: 'medium',
@@ -135,7 +135,7 @@ export const RENTAL_CAR_CONFIRMATION: PIIPattern = {
  */
 export const THEME_PARK_TICKET: PIIPattern = {
   type: 'THEME_PARK_TICKET',
-  regex: /\b(?:TICKET|PASS|ADMISSION)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
+  regex: /\b(?:TICKET|PASS|ADMISSION)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
   placeholder: '[TICKET_{n}]',
   priority: 70,
   severity: 'low',
@@ -155,7 +155,7 @@ export const THEME_PARK_TICKET: PIIPattern = {
  */
 export const TSA_PRECHECK_NUMBER: PIIPattern = {
   type: 'TSA_PRECHECK_NUMBER',
-  regex: /\b(?:TSA|PRECHECK|KTN|KNOWN[- ]?TRAVELER)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{9,10})\b/gi,
+  regex: /\b(?:TSA|PRECHECK|KTN|KNOWN[- ]?TRAVELER)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{9,10})\b/gi,
   placeholder: '[TSA_{n}]',
   priority: 85,
   severity: 'medium',
@@ -175,7 +175,7 @@ export const TSA_PRECHECK_NUMBER: PIIPattern = {
  */
 export const GLOBAL_ENTRY_NUMBER: PIIPattern = {
   type: 'GLOBAL_ENTRY_NUMBER',
-  regex: /\b(?:GLOBAL[- ]?ENTRY|PASS[- ]?ID)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{9})\b/gi,
+  regex: /\b(?:GLOBAL[- ]?ENTRY|PASS[- ]?ID)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{9})\b/gi,
   placeholder: '[GLOBAL_ENTRY_{n}]',
   priority: 85,
   severity: 'medium',

--- a/packages/core/src/patterns/industries/hr.ts
+++ b/packages/core/src/patterns/industries/hr.ts
@@ -10,7 +10,7 @@ import { PIIPattern } from '../../types';
  */
 export const EMPLOYEE_ID: PIIPattern = {
   type: 'EMPLOYEE_ID',
-  regex: /\b(?:EMPLOYEE|EMP|STAFF|PERSONNEL|WORKER)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z]{0,2}\d{4,10})\b/gi,
+  regex: /\b(?:EMPLOYEE|EMP|STAFF|PERSONNEL|WORKER)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z]{0,2}\d{4,10})\b/gi,
   placeholder: '[EMP_ID_{n}]',
   priority: 90,
   severity: 'high',
@@ -22,7 +22,7 @@ export const EMPLOYEE_ID: PIIPattern = {
  */
 export const PAYROLL_NUMBER: PIIPattern = {
   type: 'PAYROLL_NUMBER',
-  regex: /\b(?:PAYROLL|PAY)[-\s]?(?:NO|NUM(?:BER)?|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:PAYROLL|PAY)[\-\s]?(?:NO|NUM(?:BER)?|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[PAYROLL_{n}]',
   priority: 90,
   severity: 'high',
@@ -37,7 +37,7 @@ export const PAYROLL_NUMBER: PIIPattern = {
  */
 export const SALARY_AMOUNT: PIIPattern = {
   type: 'SALARY_AMOUNT',
-  regex: /\b(?:SALARY|COMPENSATION|PAY|WAGE|EARNING)[-\s]?[:#]?\s*(?:[$£€¥]\s?)?(\d{1,3}(?:[,\s]\d{3})*(?:\.\d{2})?)\b/gi,
+  regex: /\b(?:SALARY|COMPENSATION|PAY|WAGE|EARNING)[\-\s]?[:#]?\s*(?:[$£€¥]\s?)?(\d{1,3}(?:[,\s]\d{3})*(?:\.\d{2})?)\b/gi,
   placeholder: '[SALARY_{n}]',
   priority: 85,
   severity: 'high',
@@ -56,7 +56,7 @@ export const SALARY_AMOUNT: PIIPattern = {
  */
 export const PERFORMANCE_REVIEW_ID: PIIPattern = {
   type: 'PERFORMANCE_REVIEW_ID',
-  regex: /\b(?:PERFORMANCE|REVIEW|APPRAISAL|EVALUATION)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:PERFORMANCE|REVIEW|APPRAISAL|EVALUATION)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[REVIEW_{n}]',
   priority: 80,
   severity: 'high',
@@ -71,7 +71,7 @@ export const PERFORMANCE_REVIEW_ID: PIIPattern = {
  */
 export const JOB_APPLICATION_ID: PIIPattern = {
   type: 'JOB_APPLICATION_ID',
-  regex: /\b(?:APPLICATION|CANDIDATE|APPLICANT)[-\s]?(?:ID|NO|NUM(?:BER)?|REF)?[-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
+  regex: /\b(?:APPLICATION|CANDIDATE|APPLICANT)[\-\s]?(?:ID|NO|NUM(?:BER)?|REF)?[\-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
   placeholder: '[APPLICATION_{n}]',
   priority: 85,
   severity: 'high',
@@ -86,7 +86,7 @@ export const JOB_APPLICATION_ID: PIIPattern = {
  */
 export const RESUME_ID: PIIPattern = {
   type: 'RESUME_ID',
-  regex: /\b(?:RESUME|CV|CURRICULUM[-\s]?VITAE)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:RESUME|CV|CURRICULUM[\-\s]?VITAE)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[RESUME_{n}]',
   priority: 75,
   severity: 'medium',
@@ -98,7 +98,7 @@ export const RESUME_ID: PIIPattern = {
  */
 export const BENEFITS_PLAN_NUMBER: PIIPattern = {
   type: 'BENEFITS_PLAN_NUMBER',
-  regex: /\b(?:BENEFITS?|INSURANCE|HEALTH[-\s\u00A0]?PLAN)[-\s\u00A0]*(?:PLAN)?[-\s\u00A0]*(?:NO|NUM(?:BER)?|ID)?[-\s\u00A0.:#]*([A-Z0-9](?:[A-Z0-9][\s\u00A0./-]?){5,15}[A-Z0-9])\b/gi,
+  regex: /\b(?:BENEFITS?|INSURANCE|HEALTH[\-\s\u00A0]?PLAN)[\-\s\u00A0]*(?:PLAN)?[\-\s\u00A0]*(?:NO|NUM(?:BER)?|ID)?[\-\s\u00A0.:#]*([A-Z0-9](?:[A-Z0-9][\s\u00A0./-]?){5,15}[A-Z0-9])\b/gi,
   placeholder: '[BENEFITS_{n}]',
   priority: 85,
   severity: 'high',
@@ -117,7 +117,7 @@ export const BENEFITS_PLAN_NUMBER: PIIPattern = {
  */
 export const RETIREMENT_ACCOUNT: PIIPattern = {
   type: 'RETIREMENT_ACCOUNT',
-  regex: /\b(?:401K|403B|IRA|RETIREMENT|PENSION)[-\s]?(?:ACCOUNT)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
+  regex: /\b(?:401K|403B|IRA|RETIREMENT|PENSION)[\-\s]?(?:ACCOUNT)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
   placeholder: '[RETIREMENT_{n}]',
   priority: 90,
   severity: 'high',
@@ -132,13 +132,13 @@ export const RETIREMENT_ACCOUNT: PIIPattern = {
  */
 export const DIRECT_DEPOSIT_REF: PIIPattern = {
   type: 'DIRECT_DEPOSIT_REF',
-  regex: /\b(?:DIRECT[-\s]?DEPOSIT|DD|ROUTING)[-\s]?(?:NO|NUM(?:BER)?|ID)?[-\s]?[:#]?\s*(\d{9})\b/g,
+  regex: /\b(?:DIRECT[\-\s]?DEPOSIT|DD|ROUTING)[\-\s]?(?:NO|NUM(?:BER)?|ID)?[\-\s]?[:#]?\s*(\d{9})\b/g,
   placeholder: '[DD_{n}]',
   priority: 90,
   severity: 'high',
   description: 'Direct deposit and routing numbers',
   validator: (_value: string, context: string) => {
-    return /direct[-\s]?deposit|routing|bank|account|payroll|pay/i.test(context);
+    return /direct[\-\s]?deposit|routing|bank|account|payroll|pay/i.test(context);
   }
 };
 
@@ -147,7 +147,7 @@ export const DIRECT_DEPOSIT_REF: PIIPattern = {
  */
 export const BACKGROUND_CHECK_ID: PIIPattern = {
   type: 'BACKGROUND_CHECK_ID',
-  regex: /\b(?:BACKGROUND[-\s]?CHECK|BGC|SCREENING)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:BACKGROUND[\-\s]?CHECK|BGC|SCREENING)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[BGC_{n}]',
   priority: 85,
   severity: 'high',
@@ -159,7 +159,7 @@ export const BACKGROUND_CHECK_ID: PIIPattern = {
  */
 export const DRUG_TEST_ID: PIIPattern = {
   type: 'DRUG_TEST_ID',
-  regex: /\b(?:DRUG[-\s]?TEST|SCREENING|URINALYSIS)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:DRUG[\-\s]?TEST|SCREENING|URINALYSIS)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[DRUG_TEST_{n}]',
   priority: 85,
   severity: 'high',
@@ -174,7 +174,7 @@ export const DRUG_TEST_ID: PIIPattern = {
  */
 export const TIMESHEET_NUMBER: PIIPattern = {
   type: 'TIMESHEET_NUMBER',
-  regex: /\b(?:TIMESHEET|TIMECARD|TIME[-\s]?ENTRY)[-\s]?(?:NO|NUM(?:BER)?|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:TIMESHEET|TIMECARD|TIME[\-\s]?ENTRY)[\-\s]?(?:NO|NUM(?:BER)?|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[TIMESHEET_{n}]',
   priority: 75,
   severity: 'medium',
@@ -186,7 +186,7 @@ export const TIMESHEET_NUMBER: PIIPattern = {
  */
 export const TRAINING_CERT_ID: PIIPattern = {
   type: 'TRAINING_CERT_ID',
-  regex: /\b(?:TRAINING|CERTIFICATION|CERT)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:TRAINING|CERTIFICATION|CERT)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[TRAINING_{n}]',
   priority: 70,
   severity: 'medium',
@@ -201,7 +201,7 @@ export const TRAINING_CERT_ID: PIIPattern = {
  */
 export const EXPENSE_REPORT_NUMBER: PIIPattern = {
   type: 'EXPENSE_REPORT_NUMBER',
-  regex: /\b(?:EXPENSE|REIMBURSEMENT)[-\s]?(?:REPORT)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:EXPENSE|REIMBURSEMENT)[\-\s]?(?:REPORT)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[EXPENSE_{n}]',
   priority: 75,
   severity: 'medium',
@@ -216,13 +216,13 @@ export const EXPENSE_REPORT_NUMBER: PIIPattern = {
  */
 export const LEAVE_REQUEST_ID: PIIPattern = {
   type: 'LEAVE_REQUEST_ID',
-  regex: /\b(?:PTO|LEAVE|VACATION|TIME[-\s]?OFF)[-\s]?(?:REQUEST)?[-\s]?(?:NO|NUM(?:BER)?|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:PTO|LEAVE|VACATION|TIME[\-\s]?OFF)[\-\s]?(?:REQUEST)?[\-\s]?(?:NO|NUM(?:BER)?|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[LEAVE_{n}]',
   priority: 75,
   severity: 'medium',
   description: 'Leave request and time-off identifiers',
   validator: (_value: string, context: string) => {
-    return /pto|leave|vacation|time[-\s]?off|absence|sick|personal/i.test(context);
+    return /pto|leave|vacation|time[\-\s]?off|absence|sick|personal/i.test(context);
   }
 };
 
@@ -231,7 +231,7 @@ export const LEAVE_REQUEST_ID: PIIPattern = {
  */
 export const EXIT_INTERVIEW_ID: PIIPattern = {
   type: 'EXIT_INTERVIEW_ID',
-  regex: /\b(?:EXIT|TERMINATION|SEPARATION)[-\s]?(?:INTERVIEW)?[-\s]?(?:NO|NUM(?:BER)?|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:EXIT|TERMINATION|SEPARATION)[\-\s]?(?:INTERVIEW)?[\-\s]?(?:NO|NUM(?:BER)?|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[EXIT_{n}]',
   priority: 80,
   severity: 'high',
@@ -246,7 +246,7 @@ export const EXIT_INTERVIEW_ID: PIIPattern = {
  */
 export const DISCIPLINARY_ACTION_ID: PIIPattern = {
   type: 'DISCIPLINARY_ACTION_ID',
-  regex: /\b(?:DISCIPLINARY|INCIDENT|WARNING|VIOLATION)[-\s\u00A0]*(?:ACTION)?[-\s\u00A0]*(?:NO|NUM(?:BER)?|ID)?[-\s\u00A0.:#]*([A-Z0-9](?:[A-Z0-9][\s\u00A0./-]?){5,15}[A-Z0-9])\b/gi,
+  regex: /\b(?:DISCIPLINARY|INCIDENT|WARNING|VIOLATION)[\-\s\u00A0]*(?:ACTION)?[\-\s\u00A0]*(?:NO|NUM(?:BER)?|ID)?[\-\s\u00A0.:#]*([A-Z0-9](?:[A-Z0-9][\s\u00A0./-]?){5,15}[A-Z0-9])\b/gi,
   placeholder: '[DISCIPLINE_{n}]',
   priority: 85,
   severity: 'high',
@@ -264,13 +264,13 @@ export const DISCIPLINARY_ACTION_ID: PIIPattern = {
  */
 export const EMERGENCY_CONTACT_REF: PIIPattern = {
   type: 'EMERGENCY_CONTACT_REF',
-  regex: /\b(?:EMERGENCY[-\s]?CONTACT|ICE)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:EMERGENCY[\-\s]?CONTACT|ICE)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[EMERGENCY_{n}]',
   priority: 85,
   severity: 'high',
   description: 'Emergency contact reference numbers',
   validator: (_value: string, context: string) => {
-    return /emergency|contact|ice|next[-\s]?of[-\s]?kin/i.test(context);
+    return /emergency|contact|ice|next[\-\s]?of[\-\s]?kin/i.test(context);
   }
 };
 
@@ -279,7 +279,7 @@ export const EMERGENCY_CONTACT_REF: PIIPattern = {
  */
 export const WORK_PERMIT: PIIPattern = {
   type: 'WORK_PERMIT',
-  regex: /\b(?:WORK[-\s]?PERMIT|VISA|H1B|GREEN[-\s]?CARD|EAD)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,15})\b/gi,
+  regex: /\b(?:WORK[\-\s]?PERMIT|VISA|H1B|GREEN[\-\s]?CARD|EAD)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,15})\b/gi,
   placeholder: '[WORK_PERMIT_{n}]',
   priority: 90,
   severity: 'high',
@@ -291,7 +291,7 @@ export const WORK_PERMIT: PIIPattern = {
  */
 export const SECURITY_CLEARANCE: PIIPattern = {
   type: 'SECURITY_CLEARANCE',
-  regex: /\b(?:CLEARANCE|SECURITY[-\s]?LEVEL)[-\s]?[:#]?\s*(TOP[-\s]?SECRET|SECRET|CONFIDENTIAL|[A-Z]{2,3}\/SCI)\b/gi,
+  regex: /\b(?:CLEARANCE|SECURITY[\-\s]?LEVEL)[\-\s]?[:#]?\s*(TOP[\-\s]?SECRET|SECRET|CONFIDENTIAL|[A-Z]{2,3}\/SCI)\b/gi,
   placeholder: '[CLEARANCE_{n}]',
   priority: 90,
   severity: 'high',
@@ -303,7 +303,7 @@ export const SECURITY_CLEARANCE: PIIPattern = {
  */
 export const RECRUITER_REF: PIIPattern = {
   type: 'RECRUITER_REF',
-  regex: /\b(?:RECRUITER|AGENCY)[-\s]?(?:REF|ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:RECRUITER|AGENCY)[\-\s]?(?:REF|ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[RECRUITER_{n}]',
   priority: 70,
   severity: 'medium',

--- a/packages/core/src/patterns/industries/insurance.ts
+++ b/packages/core/src/patterns/industries/insurance.ts
@@ -10,7 +10,7 @@ import { PIIPattern } from '../../types';
  */
 export const CLAIM_ID: PIIPattern = {
   type: 'CLAIM_ID',
-  regex: /\bCLAIM[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*(\d{8,12})\b/gi,
+  regex: /\bCLAIM[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*(\d{8,12})\b/gi,
   placeholder: '[CLAIM_{n}]',
   priority: 90,
   severity: 'high',
@@ -25,7 +25,7 @@ export const CLAIM_ID: PIIPattern = {
  */
 export const POLICY_NUMBER: PIIPattern = {
   type: 'POLICY_NUMBER',
-  regex: /\bPOLICY[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z]{2,4}\d{6,10})\b/gi,
+  regex: /\bPOLICY[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z]{2,4}\d{6,10})\b/gi,
   placeholder: '[POLICY_{n}]',
   priority: 90,
   severity: 'high',
@@ -37,7 +37,7 @@ export const POLICY_NUMBER: PIIPattern = {
  */
 export const POLICY_HOLDER_ID: PIIPattern = {
   type: 'POLICY_HOLDER_ID',
-  regex: /\b(?:POLICY[-\s]?HOLDER|INSURED|POLICYHOLDER)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9-]{8,14})\b/gi,
+  regex: /\b(?:POLICY[\-\s]?HOLDER|INSURED|POLICYHOLDER)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9-]{8,14})\b/gi,
   placeholder: '[HOLDER_{n}]',
   priority: 85,
   severity: 'high',
@@ -49,7 +49,7 @@ export const POLICY_HOLDER_ID: PIIPattern = {
  */
 export const QUOTE_REFERENCE: PIIPattern = {
   type: 'QUOTE_REFERENCE',
-  regex: /\b(?:QUOTE|QTE)[-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:QUOTE|QTE)[\-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[QUOTE_{n}]',
   priority: 75,
   severity: 'medium',
@@ -64,7 +64,7 @@ export const QUOTE_REFERENCE: PIIPattern = {
  */
 export const INSURANCE_CERTIFICATE: PIIPattern = {
   type: 'INSURANCE_CERTIFICATE',
-  regex: /\b(?:CERTIFICATE|CERT)[-\s]?(?:OF[-\s]?INSURANCE)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:CERTIFICATE|CERT)[\-\s]?(?:OF[\-\s]?INSURANCE)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[CERT_{n}]',
   priority: 80,
   severity: 'high',
@@ -79,7 +79,7 @@ export const INSURANCE_CERTIFICATE: PIIPattern = {
  */
 export const ADJUSTER_ID: PIIPattern = {
   type: 'ADJUSTER_ID',
-  regex: /\b(?:ADJUSTER|ADJ)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:ADJUSTER|ADJ)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[ADJUSTER_{n}]',
   priority: 75,
   severity: 'medium',
@@ -94,7 +94,7 @@ export const ADJUSTER_ID: PIIPattern = {
  */
 export const UNDERWRITER_ID: PIIPattern = {
   type: 'UNDERWRITER_ID',
-  regex: /\b(?:UNDERWRITER|UW)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:UNDERWRITER|UW)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[UW_{n}]',
   priority: 75,
   severity: 'medium',
@@ -109,7 +109,7 @@ export const UNDERWRITER_ID: PIIPattern = {
  */
 export const INCIDENT_REPORT_NUMBER: PIIPattern = {
   type: 'INCIDENT_REPORT_NUMBER',
-  regex: /\b(?:INCIDENT|ACCIDENT)[-\s]?(?:REPORT)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:INCIDENT|ACCIDENT)[\-\s]?(?:REPORT)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[INCIDENT_{n}]',
   priority: 85,
   severity: 'high',
@@ -124,7 +124,7 @@ export const INCIDENT_REPORT_NUMBER: PIIPattern = {
  */
 export const PREMIUM_PAYMENT_REF: PIIPattern = {
   type: 'PREMIUM_PAYMENT_REF',
-  regex: /\b(?:PREMIUM)[-\s]?(?:PAYMENT)?[-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:PREMIUM)[\-\s]?(?:PAYMENT)?[\-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[PREMIUM_{n}]',
   priority: 80,
   severity: 'medium',
@@ -136,7 +136,7 @@ export const PREMIUM_PAYMENT_REF: PIIPattern = {
  */
 export const REINSURANCE_TREATY: PIIPattern = {
   type: 'REINSURANCE_TREATY',
-  regex: /\b(?:REINSURANCE|TREATY)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:REINSURANCE|TREATY)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[TREATY_{n}]',
   priority: 75,
   severity: 'medium',

--- a/packages/core/src/patterns/industries/legal.ts
+++ b/packages/core/src/patterns/industries/legal.ts
@@ -10,7 +10,7 @@ import { PIIPattern } from '../../types';
  */
 export const CASE_NUMBER: PIIPattern = {
   type: 'CASE_NUMBER',
-  regex: /\b(?:CASE|DOCKET|FILE)[-\s]?(?:NO|NUM(?:BER)?|REF)?[-\s]?[:#]?\s*([A-Z]{1,3}[-]?\d{2,4}[-]?[A-Z]{0,3}[-]?\d{4,8})\b/gi,
+  regex: /\b(?:CASE|DOCKET|FILE)[\-\s]?(?:NO|NUM(?:BER)?|REF)?[\-\s]?[:#]?\s*([A-Z]{1,3}[-]?\d{2,4}[-]?[A-Z]{0,3}[-]?\d{4,8})\b/gi,
   placeholder: '[CASE_{n}]',
   priority: 85,
   severity: 'high',
@@ -22,7 +22,7 @@ export const CASE_NUMBER: PIIPattern = {
  */
 export const MATTER_NUMBER: PIIPattern = {
   type: 'MATTER_NUMBER',
-  regex: /\b(?:MATTER|ENGAGEMENT|CLIENT[-\s]?MATTER)[-\s]?(?:NO|NUM(?:BER)?|REF|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:MATTER|ENGAGEMENT|CLIENT[\-\s]?MATTER)[\-\s]?(?:NO|NUM(?:BER)?|REF|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[MATTER_{n}]',
   priority: 80,
   severity: 'high',
@@ -37,7 +37,7 @@ export const MATTER_NUMBER: PIIPattern = {
  */
 export const BAR_NUMBER: PIIPattern = {
   type: 'BAR_NUMBER',
-  regex: /\b(?:BAR|ATTORNEY|LAWYER)[-\s]?(?:NO|NUM(?:BER)?|REG(?:ISTRATION)?|LIC(?:ENSE)?)?[-\s]?[:#]?\s*([A-Z0-9]{5,12})\b/gi,
+  regex: /\b(?:BAR|ATTORNEY|LAWYER)[\-\s]?(?:NO|NUM(?:BER)?|REG(?:ISTRATION)?|LIC(?:ENSE)?)?[\-\s]?[:#]?\s*([A-Z0-9]{5,12})\b/gi,
   placeholder: '[BAR_{n}]',
   priority: 85,
   severity: 'high',
@@ -49,7 +49,7 @@ export const BAR_NUMBER: PIIPattern = {
  */
 export const EXHIBIT_NUMBER: PIIPattern = {
   type: 'EXHIBIT_NUMBER',
-  regex: /\bEXHIBIT[-\s]?([A-Z]{1,2}[-]?\d{1,4})\b/gi,
+  regex: /\bEXHIBIT[\-\s]?([A-Z]{1,2}[-]?\d{1,4})\b/gi,
   placeholder: '[EXHIBIT_{n}]',
   priority: 70,
   severity: 'medium',
@@ -64,7 +64,7 @@ export const EXHIBIT_NUMBER: PIIPattern = {
  */
 export const DEPOSITION_REF: PIIPattern = {
   type: 'DEPOSITION_REF',
-  regex: /\b(?:DEPOSITION|DEPO|DEP)[-\s]?(?:NO|NUM(?:BER)?|REF|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:DEPOSITION|DEPO|DEP)[\-\s]?(?:NO|NUM(?:BER)?|REF|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[DEPO_{n}]',
   priority: 75,
   severity: 'medium',
@@ -79,7 +79,7 @@ export const DEPOSITION_REF: PIIPattern = {
  */
 export const DISCOVERY_NUMBER: PIIPattern = {
   type: 'DISCOVERY_NUMBER',
-  regex: /\b(?:DISCOVERY|INTERROGATORY|REQUEST|RFP|RFA)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{1,4}[-]?\d{1,4})\b/gi,
+  regex: /\b(?:DISCOVERY|INTERROGATORY|REQUEST|RFP|RFA)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{1,4}[-]?\d{1,4})\b/gi,
   placeholder: '[DISCOVERY_{n}]',
   priority: 75,
   severity: 'medium',
@@ -91,7 +91,7 @@ export const DISCOVERY_NUMBER: PIIPattern = {
  */
 export const COURT_REPORTER_LICENSE: PIIPattern = {
   type: 'COURT_REPORTER_LICENSE',
-  regex: /\b(?:COURT[-\s]?REPORTER|CSR|RPR)[-\s]?(?:LIC(?:ENSE)?|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z]{2,3}[-]?\d{4,8})\b/gi,
+  regex: /\b(?:COURT[\-\s]?REPORTER|CSR|RPR)[\-\s]?(?:LIC(?:ENSE)?|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z]{2,3}[-]?\d{4,8})\b/gi,
   placeholder: '[CSR_{n}]',
   priority: 75,
   severity: 'medium',
@@ -103,7 +103,7 @@ export const COURT_REPORTER_LICENSE: PIIPattern = {
  */
 export const SUBPOENA_NUMBER: PIIPattern = {
   type: 'SUBPOENA_NUMBER',
-  regex: /\b(?:SUBPOENA|SUMMONS)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:SUBPOENA|SUMMONS)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[SUBPOENA_{n}]',
   priority: 80,
   severity: 'high',
@@ -115,7 +115,7 @@ export const SUBPOENA_NUMBER: PIIPattern = {
  */
 export const JUDGMENT_NUMBER: PIIPattern = {
   type: 'JUDGMENT_NUMBER',
-  regex: /\b(?:JUDGMENT|ORDER|DECREE)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:JUDGMENT|ORDER|DECREE)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[JUDGMENT_{n}]',
   priority: 80,
   severity: 'high',
@@ -130,7 +130,7 @@ export const JUDGMENT_NUMBER: PIIPattern = {
  */
 export const PATENT_NUMBER: PIIPattern = {
   type: 'PATENT_NUMBER',
-  regex: /\b(?:(?:US|EP|WO|PCT)[-\s]?)?(?:PATENT|PAT)[-\s]?(?:NO|NUM(?:BER)?|APPL(?:ICATION)?)?[-\s]?[:#]?\s*([A-Z]{0,2}\d{6,10}[A-Z0-9]{0,3})\b/gi,
+  regex: /\b(?:(?:US|EP|WO|PCT)[\-\s]?)?(?:PATENT|PAT)[\-\s]?(?:NO|NUM(?:BER)?|APPL(?:ICATION)?)?[\-\s]?[:#]?\s*([A-Z]{0,2}\d{6,10}[A-Z0-9]{0,3})\b/gi,
   placeholder: '[PATENT_{n}]',
   priority: 75,
   severity: 'medium',
@@ -142,7 +142,7 @@ export const PATENT_NUMBER: PIIPattern = {
  */
 export const SETTLEMENT_ID: PIIPattern = {
   type: 'SETTLEMENT_ID',
-  regex: /\b(?:SETTLEMENT|AGREEMENT)[-\s]?(?:ID|NO|NUM(?:BER)?|REF)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:SETTLEMENT|AGREEMENT)[\-\s]?(?:ID|NO|NUM(?:BER)?|REF)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[SETTLEMENT_{n}]',
   priority: 85,
   severity: 'high',
@@ -157,7 +157,7 @@ export const SETTLEMENT_ID: PIIPattern = {
  */
 export const CLIENT_ID: PIIPattern = {
   type: 'CLIENT_ID',
-  regex: /\b(?:CLIENT)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:CLIENT)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[CLIENT_{n}]',
   priority: 90,
   severity: 'high',
@@ -172,7 +172,7 @@ export const CLIENT_ID: PIIPattern = {
  */
 export const RETAINER_NUMBER: PIIPattern = {
   type: 'RETAINER_NUMBER',
-  regex: /\b(?:RETAINER)[-\s]?(?:NO|NUM(?:BER)?|AGREEMENT)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:RETAINER)[\-\s]?(?:NO|NUM(?:BER)?|AGREEMENT)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[RETAINER_{n}]',
   priority: 80,
   severity: 'high',
@@ -184,7 +184,7 @@ export const RETAINER_NUMBER: PIIPattern = {
  */
 export const NOTARY_LICENSE: PIIPattern = {
   type: 'NOTARY_LICENSE',
-  regex: /\b(?:NOTARY|NOTARIAL)[-\s]?(?:LIC(?:ENSE)?|COMMISSION|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:NOTARY|NOTARIAL)[\-\s]?(?:LIC(?:ENSE)?|COMMISSION|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[NOTARY_{n}]',
   priority: 75,
   severity: 'medium',
@@ -196,7 +196,7 @@ export const NOTARY_LICENSE: PIIPattern = {
  */
 export const BANKRUPTCY_CASE: PIIPattern = {
   type: 'BANKRUPTCY_CASE',
-  regex: /\b(?:BK|BANKRUPTCY)[-\s]?(?:NO|NUM(?:BER)?|CASE)?[-\s]?[:#]?\s*(\d{2}[-]?\d{5}[-]?[A-Z]{0,3})\b/gi,
+  regex: /\b(?:BK|BANKRUPTCY)[\-\s]?(?:NO|NUM(?:BER)?|CASE)?[\-\s]?[:#]?\s*(\d{2}[-]?\d{5}[-]?[A-Z]{0,3})\b/gi,
   placeholder: '[BK_{n}]',
   priority: 85,
   severity: 'high',
@@ -208,7 +208,7 @@ export const BANKRUPTCY_CASE: PIIPattern = {
  */
 export const PROBATE_CASE: PIIPattern = {
   type: 'PROBATE_CASE',
-  regex: /\b(?:PROBATE|ESTATE)[-\s]?(?:NO|NUM(?:BER)?|CASE)?[-\s]?[:#]?\s*([A-Z]{1,2}\d{6,10})\b/gi,
+  regex: /\b(?:PROBATE|ESTATE)[\-\s]?(?:NO|NUM(?:BER)?|CASE)?[\-\s]?[:#]?\s*([A-Z]{1,2}\d{6,10})\b/gi,
   placeholder: '[PROBATE_{n}]',
   priority: 85,
   severity: 'high',
@@ -223,7 +223,7 @@ export const PROBATE_CASE: PIIPattern = {
  */
 export const NDA_ID: PIIPattern = {
   type: 'NDA_ID',
-  regex: /\b(?:NDA|CONFIDENTIALITY|NON[-\s]?DISCLOSURE)[-\s]?(?:AGREEMENT)?[-\s]?(?:NO|NUM(?:BER)?|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:NDA|CONFIDENTIALITY|NON[\-\s]?DISCLOSURE)[\-\s]?(?:AGREEMENT)?[\-\s]?(?:NO|NUM(?:BER)?|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[NDA_{n}]',
   priority: 75,
   severity: 'high',
@@ -235,7 +235,7 @@ export const NDA_ID: PIIPattern = {
  */
 export const CONTRACT_REFERENCE: PIIPattern = {
   type: 'CONTRACT_REFERENCE',
-  regex: /\bCNTR[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*(\d{8})\b/gi,
+  regex: /\bCNTR[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*(\d{8})\b/gi,
   placeholder: '[CONTRACT_{n}]',
   priority: 85,
   severity: 'high',

--- a/packages/core/src/patterns/industries/logistics.ts
+++ b/packages/core/src/patterns/industries/logistics.ts
@@ -11,7 +11,7 @@ import type { PIIPattern } from '../../types';
  */
 export const FEDEX_TRACKING: PIIPattern = {
   type: 'FEDEX_TRACKING',
-  regex: /\b(?:FEDEX|FDX)[-\s]?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{12}|\d{15}|\d{20})\b/gi,
+  regex: /\b(?:FEDEX|FDX)[\-\s]?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{12}|\d{15}|\d{20})\b/gi,
   placeholder: '[FEDEX_TRACK_{n}]',
   priority: 85,
   severity: 'low',
@@ -30,7 +30,7 @@ export const FEDEX_TRACKING: PIIPattern = {
  */
 export const UPS_TRACKING: PIIPattern = {
   type: 'UPS_TRACKING',
-  regex: /\b(?:UPS[-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*(1Z[A-Z0-9]{16})\b/gi,
+  regex: /\b(?:UPS[\-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(1Z[A-Z0-9]{16})\b/gi,
   placeholder: '[UPS_TRACK_{n}]',
   priority: 90,
   severity: 'low',
@@ -49,7 +49,7 @@ export const UPS_TRACKING: PIIPattern = {
  */
 export const USPS_TRACKING: PIIPattern = {
   type: 'USPS_TRACKING',
-  regex: /\b(?:USPS|US\s?MAIL)[-\s]?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{20,22}|[A-Z]{2}\d{9}US)\b/gi,
+  regex: /\b(?:USPS|US\s?MAIL)[\-\s]?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{20,22}|[A-Z]{2}\d{9}US)\b/gi,
   placeholder: '[USPS_TRACK_{n}]',
   priority: 85,
   severity: 'low',
@@ -75,7 +75,7 @@ export const USPS_TRACKING: PIIPattern = {
  */
 export const DHL_TRACKING: PIIPattern = {
   type: 'DHL_TRACKING',
-  regex: /\b(?:DHL[-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{10,11})\b/gi,
+  regex: /\b(?:DHL[\-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{10,11})\b/gi,
   placeholder: '[DHL_TRACK_{n}]',
   priority: 85,
   severity: 'low',
@@ -110,7 +110,7 @@ export const AMAZON_TRACKING: PIIPattern = {
  */
 export const TNT_TRACKING: PIIPattern = {
   type: 'TNT_TRACKING',
-  regex: /\b(?:TNT[-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{9}|[A-Z0-9]{13})\b/gi,
+  regex: /\b(?:TNT[\-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{9}|[A-Z0-9]{13})\b/gi,
   placeholder: '[TNT_TRACK_{n}]',
   priority: 85,
   severity: 'low',
@@ -129,7 +129,7 @@ export const TNT_TRACKING: PIIPattern = {
  */
 export const CHINA_POST_TRACKING: PIIPattern = {
   type: 'CHINA_POST_TRACKING',
-  regex: /\b(?:CHINA\s?POST[-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([RC][A-Z]\d{9}CN)\b/gi,
+  regex: /\b(?:CHINA\s?POST[\-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([RC][A-Z]\d{9}CN)\b/gi,
   placeholder: '[CHINA_POST_{n}]',
   priority: 85,
   severity: 'low',
@@ -149,7 +149,7 @@ export const CHINA_POST_TRACKING: PIIPattern = {
  */
 export const JAPAN_POST_TRACKING: PIIPattern = {
   type: 'JAPAN_POST_TRACKING',
-  regex: /\b(?:JAPAN\s?POST[-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z]{2}\d{9}JP)\b/gi,
+  regex: /\b(?:JAPAN\s?POST[\-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z]{2}\d{9}JP)\b/gi,
   placeholder: '[JAPAN_POST_{n}]',
   priority: 85,
   severity: 'low',
@@ -168,7 +168,7 @@ export const JAPAN_POST_TRACKING: PIIPattern = {
  */
 export const ROYAL_MAIL_TRACKING: PIIPattern = {
   type: 'ROYAL_MAIL_TRACKING',
-  regex: /\b(?:ROYAL\s?MAIL[-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z]{2}\d{9}GB)\b/gi,
+  regex: /\b(?:ROYAL\s?MAIL[\-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z]{2}\d{9}GB)\b/gi,
   placeholder: '[ROYAL_MAIL_{n}]',
   priority: 85,
   severity: 'low',
@@ -187,7 +187,7 @@ export const ROYAL_MAIL_TRACKING: PIIPattern = {
  */
 export const CANADA_POST_TRACKING: PIIPattern = {
   type: 'CANADA_POST_TRACKING',
-  regex: /\b(?:CANADA\s?POST[-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{16})\b/gi,
+  regex: /\b(?:CANADA\s?POST[\-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{16})\b/gi,
   placeholder: '[CANADA_POST_{n}]',
   priority: 85,
   severity: 'low',
@@ -205,7 +205,7 @@ export const CANADA_POST_TRACKING: PIIPattern = {
  */
 export const AUSTRALIA_POST_TRACKING: PIIPattern = {
   type: 'AUSTRALIA_POST_TRACKING',
-  regex: /\b(?:AUSTRALIA\s?POST[-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z]{2}\d{9}AU)\b/gi,
+  regex: /\b(?:AUSTRALIA\s?POST[\-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z]{2}\d{9}AU)\b/gi,
   placeholder: '[AUSTRALIA_POST_{n}]',
   priority: 85,
   severity: 'low',
@@ -224,7 +224,7 @@ export const AUSTRALIA_POST_TRACKING: PIIPattern = {
  */
 export const PUROLATOR_TRACKING: PIIPattern = {
   type: 'PUROLATOR_TRACKING',
-  regex: /\b(?:PUROLATOR[-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER|PIN)?[-\s]?[:#]?\s*(\d{12}|P\d{10})\b/gi,
+  regex: /\b(?:PUROLATOR[\-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER|PIN)?[\-\s]?[:#]?\s*(\d{12}|P\d{10})\b/gi,
   placeholder: '[PUROLATOR_{n}]',
   priority: 85,
   severity: 'low',
@@ -245,7 +245,7 @@ export const PUROLATOR_TRACKING: PIIPattern = {
  */
 export const ONTRAC_TRACKING: PIIPattern = {
   type: 'ONTRAC_TRACKING',
-  regex: /\b(?:ONTRAC|ON\s?TRAC|LASERSHIP)[-\s]?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*(C\d{14})\b/gi,
+  regex: /\b(?:ONTRAC|ON\s?TRAC|LASERSHIP)[\-\s]?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(C\d{14})\b/gi,
   placeholder: '[ONTRAC_{n}]',
   priority: 85,
   severity: 'low',
@@ -264,7 +264,7 @@ export const ONTRAC_TRACKING: PIIPattern = {
  */
 export const GLS_TRACKING: PIIPattern = {
   type: 'GLS_TRACKING',
-  regex: /\b(?:GLS[-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{11,13})\b/gi,
+  regex: /\b(?:GLS[\-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{11,13})\b/gi,
   placeholder: '[GLS_{n}]',
   priority: 80,
   severity: 'low',
@@ -283,7 +283,7 @@ export const GLS_TRACKING: PIIPattern = {
  */
 export const ARAMEX_TRACKING: PIIPattern = {
   type: 'ARAMEX_TRACKING',
-  regex: /\b(?:ARAMEX[-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{11,12})\b/gi,
+  regex: /\b(?:ARAMEX[\-\s]?)?(?:TRACK(?:ING)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{11,12})\b/gi,
   placeholder: '[ARAMEX_{n}]',
   priority: 85,
   severity: 'low',
@@ -302,7 +302,7 @@ export const ARAMEX_TRACKING: PIIPattern = {
  */
 export const GENERIC_TRACKING_NUMBER: PIIPattern = {
   type: 'GENERIC_TRACKING_NUMBER',
-  regex: /\b(?:TRACK(?:ING)?|SHIPMENT|PACKAGE)[-\s]?(?:ID|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{10,25})\b/gi,
+  regex: /\b(?:TRACK(?:ING)?|SHIPMENT|PACKAGE)[\-\s]?(?:ID|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{10,25})\b/gi,
   placeholder: '[TRACKING_{n}]',
   priority: 70,
   severity: 'low',
@@ -325,7 +325,7 @@ export const GENERIC_TRACKING_NUMBER: PIIPattern = {
  */
 export const BILL_OF_LADING: PIIPattern = {
   type: 'BILL_OF_LADING',
-  regex: /\b(?:BOL|B\/L|BILL\s?OF\s?LADING)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,20})\b/gi,
+  regex: /\b(?:BOL|B\/L|BILL\s?OF\s?LADING)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,20})\b/gi,
   placeholder: '[BOL_{n}]',
   priority: 85,
   severity: 'medium',
@@ -360,7 +360,7 @@ export const SHIPPING_CONTAINER_NUMBER: PIIPattern = {
  */
 export const AIR_WAYBILL_NUMBER: PIIPattern = {
   type: 'AIR_WAYBILL_NUMBER',
-  regex: /\b(?:AWB|AIR\s?WAYBILL)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{3}[-\s]?\d{8})\b/gi,
+  regex: /\b(?:AWB|AIR\s?WAYBILL)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{3}[\-\s]?\d{8})\b/gi,
   placeholder: '[AWB_{n}]',
   priority: 85,
   severity: 'medium',
@@ -379,7 +379,7 @@ export const AIR_WAYBILL_NUMBER: PIIPattern = {
  */
 export const PRO_NUMBER: PIIPattern = {
   type: 'PRO_NUMBER',
-  regex: /\bPRO[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{9,10})\b/gi,
+  regex: /\bPRO[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{9,10})\b/gi,
   placeholder: '[PRO_{n}]',
   priority: 85,
   severity: 'low',
@@ -398,7 +398,7 @@ export const PRO_NUMBER: PIIPattern = {
  */
 export const MASTER_AIRWAY_BILL: PIIPattern = {
   type: 'MASTER_AIRWAY_BILL',
-  regex: /\bMAWB[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{3}[-\s]?\d{8})\b/gi,
+  regex: /\bMAWB[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{3}[\-\s]?\d{8})\b/gi,
   placeholder: '[MAWB_{n}]',
   priority: 85,
   severity: 'medium',

--- a/packages/core/src/patterns/industries/manufacturing.ts
+++ b/packages/core/src/patterns/industries/manufacturing.ts
@@ -10,7 +10,7 @@ import { PIIPattern } from '../../types';
  */
 export const SUPPLIER_ID: PIIPattern = {
   type: 'SUPPLIER_ID',
-  regex: /\bSUPP(?:LIER)?[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z]{2}\d{5,8})\b/gi,
+  regex: /\bSUPP(?:LIER)?[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z]{2}\d{5,8})\b/gi,
   placeholder: '[SUPPLIER_{n}]',
   priority: 80,
   severity: 'medium',
@@ -22,7 +22,7 @@ export const SUPPLIER_ID: PIIPattern = {
  */
 export const PART_NUMBER: PIIPattern = {
   type: 'PART_NUMBER',
-  regex: /\bP(?:ART)?N[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([0-9A-Z]{6,12})\b/gi,
+  regex: /\bP(?:ART)?N[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([0-9A-Z]{6,12})\b/gi,
   placeholder: '[PART_{n}]',
   priority: 70,
   severity: 'low',
@@ -38,7 +38,7 @@ export const PART_NUMBER: PIIPattern = {
  */
 export const PURCHASE_ORDER_NUMBER: PIIPattern = {
   type: 'PURCHASE_ORDER_NUMBER',
-  regex: /\bP(?:URCHASE[-\s]?)?O(?:RDER)?[-\s]+(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
+  regex: /\bP(?:URCHASE[\-\s]?)?O(?:RDER)?[\-\s]+(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
   placeholder: '[PO_{n}]',
   priority: 85,
   severity: 'medium',
@@ -50,7 +50,7 @@ export const PURCHASE_ORDER_NUMBER: PIIPattern = {
  */
 export const WORK_ORDER_NUMBER: PIIPattern = {
   type: 'WORK_ORDER_NUMBER',
-  regex: /\bW(?:ORK[-\s]?)?O(?:RDER)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\bW(?:ORK[\-\s]?)?O(?:RDER)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[WO_{n}]',
   priority: 80,
   severity: 'medium',
@@ -65,7 +65,7 @@ export const WORK_ORDER_NUMBER: PIIPattern = {
  */
 export const BATCH_LOT_NUMBER: PIIPattern = {
   type: 'BATCH_LOT_NUMBER',
-  regex: /\b(?:BATCH|LOT)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
+  regex: /\b(?:BATCH|LOT)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
   placeholder: '[BATCH_{n}]',
   priority: 75,
   severity: 'medium',
@@ -80,7 +80,7 @@ export const BATCH_LOT_NUMBER: PIIPattern = {
  */
 export const MANUFACTURING_SERIAL: PIIPattern = {
   type: 'MANUFACTURING_SERIAL',
-  regex: /\b(?:SERIAL|SN)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
+  regex: /\b(?:SERIAL|SN)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
   placeholder: '[SERIAL_{n}]',
   priority: 80,
   severity: 'medium',
@@ -95,7 +95,7 @@ export const MANUFACTURING_SERIAL: PIIPattern = {
  */
 export const VENDOR_CODE: PIIPattern = {
   type: 'VENDOR_CODE',
-  regex: /\bVEND(?:OR)?[-\s]?(?:CODE)?[-\s]?[:#]?\s*([A-Z0-9]{4,10})\b/gi,
+  regex: /\bVEND(?:OR)?[\-\s]?(?:CODE)?[\-\s]?[:#]?\s*([A-Z0-9]{4,10})\b/gi,
   placeholder: '[VENDOR_{n}]',
   priority: 75,
   severity: 'medium',
@@ -110,7 +110,7 @@ export const VENDOR_CODE: PIIPattern = {
  */
 export const BOM_NUMBER: PIIPattern = {
   type: 'BOM_NUMBER',
-  regex: /\bBOM[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\bBOM[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[BOM_{n}]',
   priority: 75,
   severity: 'medium',
@@ -125,7 +125,7 @@ export const BOM_NUMBER: PIIPattern = {
  */
 export const QC_CERTIFICATE_NUMBER: PIIPattern = {
   type: 'QC_CERTIFICATE_NUMBER',
-  regex: /\b(?:QC|QUALITY)[-\s]?(?:CERT(?:IFICATE)?)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:QC|QUALITY)[\-\s]?(?:CERT(?:IFICATE)?)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[QC_{n}]',
   priority: 80,
   severity: 'medium',
@@ -140,7 +140,7 @@ export const QC_CERTIFICATE_NUMBER: PIIPattern = {
  */
 export const CONTAINER_NUMBER: PIIPattern = {
   type: 'CONTAINER_NUMBER',
-  regex: /\b(?:CONTAINER|CNTR)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z]{4}\d{7})\b/gi,
+  regex: /\b(?:CONTAINER|CNTR)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z]{4}\d{7})\b/gi,
   placeholder: '[CONTAINER_{n}]',
   priority: 80,
   severity: 'medium',
@@ -156,7 +156,7 @@ export const CONTAINER_NUMBER: PIIPattern = {
  */
 export const PALLET_ID: PIIPattern = {
   type: 'PALLET_ID',
-  regex: /\bPALLET[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
+  regex: /\bPALLET[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
   placeholder: '[PALLET_{n}]',
   priority: 70,
   severity: 'low',
@@ -171,7 +171,7 @@ export const PALLET_ID: PIIPattern = {
  */
 export const ROUTING_NUMBER_MFG: PIIPattern = {
   type: 'ROUTING_NUMBER_MFG',
-  regex: /\bROUTING[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\bROUTING[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[ROUTING_{n}]',
   priority: 75,
   severity: 'medium',
@@ -186,7 +186,7 @@ export const ROUTING_NUMBER_MFG: PIIPattern = {
  */
 export const RFQ_NUMBER: PIIPattern = {
   type: 'RFQ_NUMBER',
-  regex: /\bRFQ[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\bRFQ[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[RFQ_{n}]',
   priority: 75,
   severity: 'medium',
@@ -202,7 +202,7 @@ export const RFQ_NUMBER: PIIPattern = {
  */
 export const PROJECT_CODE: PIIPattern = {
   type: 'PROJECT_CODE',
-  regex: /\b(?:PROJECT|PROJ)[-\s]+(?:CODE)?[-\s]?[:#]?\s*([A-Z0-9]{4,10})\b/gi,
+  regex: /\b(?:PROJECT|PROJ)[\-\s]+(?:CODE)?[\-\s]?[:#]?\s*([A-Z0-9]{4,10})\b/gi,
   placeholder: '[PROJECT_{n}]',
   priority: 70,
   severity: 'low',

--- a/packages/core/src/patterns/industries/maritime.ts
+++ b/packages/core/src/patterns/industries/maritime.ts
@@ -11,7 +11,7 @@ import type { PIIPattern } from '../../types';
  */
 export const IMO_NUMBER: PIIPattern = {
   type: 'IMO_NUMBER',
-  regex: /\bIMO[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{7})\b/gi,
+  regex: /\bIMO[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{7})\b/gi,
   placeholder: '[IMO_{n}]',
   priority: 90,
   severity: 'medium',
@@ -39,7 +39,7 @@ export const IMO_NUMBER: PIIPattern = {
  */
 export const MMSI_NUMBER: PIIPattern = {
   type: 'MMSI_NUMBER',
-  regex: /\bMMSI[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{9})\b/gi,
+  regex: /\bMMSI[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{9})\b/gi,
   placeholder: '[MMSI_{n}]',
   priority: 90,
   severity: 'medium',
@@ -62,7 +62,7 @@ export const MMSI_NUMBER: PIIPattern = {
  */
 export const MARITIME_CALLSIGN: PIIPattern = {
   type: 'MARITIME_CALLSIGN',
-  regex: /\b(?:CALLSIGN|CALL\s?SIGN)[-\s]?[:#]?\s*([A-Z0-9]{3,7})\b/gi,
+  regex: /\b(?:CALLSIGN|CALL\s?SIGN)[\-\s]?[:#]?\s*([A-Z0-9]{3,7})\b/gi,
   placeholder: '[CALLSIGN_{n}]',
   priority: 85,
   severity: 'low',
@@ -78,7 +78,7 @@ export const MARITIME_CALLSIGN: PIIPattern = {
  */
 export const OFFICIAL_SHIP_NUMBER: PIIPattern = {
   type: 'OFFICIAL_SHIP_NUMBER',
-  regex: /\b(?:OFFICIAL|SHIP)[-\s]?(?:NO|NUM|NUMBER)[-\s]?[:#]?\s*([A-Z0-9]{5,12})\b/gi,
+  regex: /\b(?:OFFICIAL|SHIP)[\-\s]?(?:NO|NUM|NUMBER)[\-\s]?[:#]?\s*([A-Z0-9]{5,12})\b/gi,
   placeholder: '[SHIP_NUM_{n}]',
   priority: 80,
   severity: 'medium',
@@ -94,7 +94,7 @@ export const OFFICIAL_SHIP_NUMBER: PIIPattern = {
  */
 export const PSC_INSPECTION_ID: PIIPattern = {
   type: 'PSC_INSPECTION_ID',
-  regex: /\b(?:PSC|INSPECTION)[-\s]?(?:ID|NO|NUM|NUMBER)[-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
+  regex: /\b(?:PSC|INSPECTION)[\-\s]?(?:ID|NO|NUM|NUMBER)[\-\s]?[:#]?\s*([A-Z0-9]{6,15})\b/gi,
   placeholder: '[PSC_{n}]',
   priority: 80,
   severity: 'low',
@@ -110,7 +110,7 @@ export const PSC_INSPECTION_ID: PIIPattern = {
  */
 export const SEAFARER_ID: PIIPattern = {
   type: 'SEAFARER_ID',
-  regex: /\b(?:SEAFARER|MARINER|SID)[-\s]?(?:ID|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z]{2,3}[A-Z0-9]{9})\b/gi,
+  regex: /\b(?:SEAFARER|MARINER|SID)[\-\s]?(?:ID|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z]{2,3}[A-Z0-9]{9})\b/gi,
   placeholder: '[SEAFARER_{n}]',
   priority: 85,
   severity: 'high',
@@ -128,7 +128,7 @@ export const SEAFARER_ID: PIIPattern = {
  */
 export const LLOYDS_REGISTER_NUMBER: PIIPattern = {
   type: 'LLOYDS_REGISTER_NUMBER',
-  regex: /\b(?:LLOYD'?S?|LR)[-\s]?(?:REG(?:ISTER)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{7})\b/gi,
+  regex: /\b(?:LLOYD'?S?|LR)[\-\s]?(?:REG(?:ISTER)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{7})\b/gi,
   placeholder: '[LR_NUM_{n}]',
   priority: 85,
   severity: 'low',

--- a/packages/core/src/patterns/industries/media.ts
+++ b/packages/core/src/patterns/industries/media.ts
@@ -10,7 +10,7 @@ import { PIIPattern } from '../../types';
  */
 export const INTERVIEWEE_ID: PIIPattern = {
   type: 'INTERVIEWEE_ID',
-  regex: /\bINTV[-\s]?([A-Z]{1}\d{5})\b/gi,
+  regex: /\bINTV[\-\s]?([A-Z]{1}\d{5})\b/gi,
   placeholder: '[INTERVIEWEE_{n}]',
   priority: 85,
   severity: 'high',
@@ -22,7 +22,7 @@ export const INTERVIEWEE_ID: PIIPattern = {
  */
 export const SOURCE_ID: PIIPattern = {
   type: 'SOURCE_ID',
-  regex: /\bSOURCE[-\s]?(?:ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\bSOURCE[\-\s]?(?:ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[SOURCE_{n}]',
   priority: 90,
   severity: 'high',
@@ -37,7 +37,7 @@ export const SOURCE_ID: PIIPattern = {
  */
 export const ARTICLE_ID: PIIPattern = {
   type: 'ARTICLE_ID',
-  regex: /\b(?:ARTICLE|STORY)[-\s]?(?:ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:ARTICLE|STORY)[\-\s]?(?:ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[ARTICLE_{n}]',
   priority: 70,
   severity: 'low',
@@ -52,7 +52,7 @@ export const ARTICLE_ID: PIIPattern = {
  */
 export const MANUSCRIPT_ID: PIIPattern = {
   type: 'MANUSCRIPT_ID',
-  regex: /\b(?:MANUSCRIPT|MS)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:MANUSCRIPT|MS)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[MANUSCRIPT_{n}]',
   priority: 75,
   severity: 'medium',
@@ -67,7 +67,7 @@ export const MANUSCRIPT_ID: PIIPattern = {
  */
 export const PRESS_PASS_ID: PIIPattern = {
   type: 'PRESS_PASS_ID',
-  regex: /\b(?:PRESS[-\s]?PASS|MEDIA[-\s]?CREDENTIAL)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:PRESS[\-\s]?PASS|MEDIA[\-\s]?CREDENTIAL)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[PRESS_{n}]',
   priority: 80,
   severity: 'medium',
@@ -82,7 +82,7 @@ export const PRESS_PASS_ID: PIIPattern = {
  */
 export const CONTRIBUTOR_ID: PIIPattern = {
   type: 'CONTRIBUTOR_ID',
-  regex: /\b(?:CONTRIBUTOR|FREELANCER|WRITER)[-\s]?(?:ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:CONTRIBUTOR|FREELANCER|WRITER)[\-\s]?(?:ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[CONTRIBUTOR_{n}]',
   priority: 75,
   severity: 'medium',
@@ -97,7 +97,7 @@ export const CONTRIBUTOR_ID: PIIPattern = {
  */
 export const PUBLISHING_CONTRACT: PIIPattern = {
   type: 'PUBLISHING_CONTRACT',
-  regex: /\b(?:PUBLISHING|PUB)[-\s]?(?:CONTRACT)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:PUBLISHING|PUB)[\-\s]?(?:CONTRACT)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[PUB_CONTRACT_{n}]',
   priority: 80,
   severity: 'high',
@@ -112,7 +112,7 @@ export const PUBLISHING_CONTRACT: PIIPattern = {
  */
 export const EDITORIAL_TICKET: PIIPattern = {
   type: 'EDITORIAL_TICKET',
-  regex: /\b(?:EDITORIAL|EDIT)[-\s]?(?:TICKET|TASK)?[-\s]?(?:ID|NO)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:EDITORIAL|EDIT)[\-\s]?(?:TICKET|TASK)?[\-\s]?(?:ID|NO)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[EDIT_{n}]',
   priority: 70,
   severity: 'low',
@@ -127,7 +127,7 @@ export const EDITORIAL_TICKET: PIIPattern = {
  */
 export const SUBSCRIBER_ID: PIIPattern = {
   type: 'SUBSCRIBER_ID',
-  regex: /\bSUBSCRIBER[-\s]?(?:ID)?[-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
+  regex: /\bSUBSCRIBER[\-\s]?(?:ID)?[\-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
   placeholder: '[SUBSCRIBER_{n}]',
   priority: 85,
   severity: 'high',
@@ -142,7 +142,7 @@ export const SUBSCRIBER_ID: PIIPattern = {
  */
 export const ISBN: PIIPattern = {
   type: 'ISBN',
-  regex: /\bISBN[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*(\d{3}[-\s]?\d{1,5}[-\s]?\d{1,7}[-\s]?\d{1,7}[-\s]?\d{1})\b/gi,
+  regex: /\bISBN[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*(\d{3}[\-\s]?\d{1,5}[\-\s]?\d{1,7}[\-\s]?\d{1,7}[\-\s]?\d{1})\b/gi,
   placeholder: '[ISBN_{n}]',
   priority: 65,
   severity: 'low',
@@ -154,7 +154,7 @@ export const ISBN: PIIPattern = {
  */
 export const COPYRIGHT_REG: PIIPattern = {
   type: 'COPYRIGHT_REG',
-  regex: /\b(?:COPYRIGHT|©)[-\s]?(?:REG(?:ISTRATION)?)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z]{2,3}\d{6,10})\b/gi,
+  regex: /\b(?:COPYRIGHT|©)[\-\s]?(?:REG(?:ISTRATION)?)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z]{2,3}\d{6,10})\b/gi,
   placeholder: '[COPYRIGHT_{n}]',
   priority: 75,
   severity: 'medium',
@@ -169,7 +169,7 @@ export const COPYRIGHT_REG: PIIPattern = {
  */
 export const PRODUCTION_ID: PIIPattern = {
   type: 'PRODUCTION_ID',
-  regex: /\b(?:PRODUCTION|PROD)[-\s]?(?:ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:PRODUCTION|PROD)[\-\s]?(?:ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[PRODUCTION_{n}]',
   priority: 70,
   severity: 'low',

--- a/packages/core/src/patterns/industries/procurement.ts
+++ b/packages/core/src/patterns/industries/procurement.ts
@@ -122,7 +122,7 @@ export const REQUISITION_NUMBER: PIIPattern = {
  */
 export const PCARD_REFERENCE: PIIPattern = {
   type: 'PCARD_REFERENCE',
-  regex: /\b(?:P[-\s]?Card|Procurement\s+Card).*?(?:ending|last\s+4|XXXX)[-\s]?(\d{4})\b/gi,
+  regex: /\b(?:P[\-\s]?Card|Procurement\s+Card).*?(?:ending|last\s+4|XXXX)[\-\s]?(\d{4})\b/gi,
   placeholder: '[PCARD_{n}]',
   priority: 90,
   severity: 'high',

--- a/packages/core/src/patterns/industries/professional-certifications.ts
+++ b/packages/core/src/patterns/industries/professional-certifications.ts
@@ -12,7 +12,7 @@ import { PIIPattern } from '../../types';
  */
 export const PMP_CERTIFICATION: PIIPattern = {
   type: 'PMP_CERTIFICATION',
-  regex: /\bPMP[-\s]?(?:ID|NO|NUM|NUMBER|CERT(?:IFICATION)?)?[-\s]?[:#]?\s*(\d{7,9})\b/gi,
+  regex: /\bPMP[\-\s]?(?:ID|NO|NUM|NUMBER|CERT(?:IFICATION)?)?[\-\s]?[:#]?\s*(\d{7,9})\b/gi,
   placeholder: '[PMP_{n}]',
   priority: 80,
   severity: 'medium',
@@ -32,7 +32,7 @@ export const PMP_CERTIFICATION: PIIPattern = {
  */
 export const CPA_LICENSE: PIIPattern = {
   type: 'CPA_LICENSE',
-  regex: /\bCPA[-\s]?(?:LICENSE|LIC|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{5,10})\b/gi,
+  regex: /\bCPA[\-\s]?(?:LICENSE|LIC|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{5,10})\b/gi,
   placeholder: '[CPA_{n}]',
   priority: 85,
   severity: 'medium',
@@ -49,7 +49,7 @@ export const CPA_LICENSE: PIIPattern = {
  */
 export const PE_LICENSE: PIIPattern = {
   type: 'PE_LICENSE',
-  regex: /\bPE[-\s]?(?:LICENSE|LIC|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{5,10})\b/gi,
+  regex: /\bPE[\-\s]?(?:LICENSE|LIC|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{5,10})\b/gi,
   placeholder: '[PE_{n}]',
   priority: 80,
   severity: 'medium',
@@ -66,7 +66,7 @@ export const PE_LICENSE: PIIPattern = {
  */
 export const NURSING_LICENSE: PIIPattern = {
   type: 'NURSING_LICENSE',
-  regex: /\b(?:RN|LPN|NP|NURSING)[-\s]?(?:LICENSE|LIC|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:RN|LPN|NP|NURSING)[\-\s]?(?:LICENSE|LIC|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[RN_{n}]',
   priority: 85,
   severity: 'high',
@@ -83,7 +83,7 @@ export const NURSING_LICENSE: PIIPattern = {
  */
 export const TEACHING_LICENSE: PIIPattern = {
   type: 'TEACHING_LICENSE',
-  regex: /\b(?:TEACHING|TEACHER|EDUCATOR)[-\s]?(?:LICENSE|LIC|CERT(?:IFICATE)?|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:TEACHING|TEACHER|EDUCATOR)[\-\s]?(?:LICENSE|LIC|CERT(?:IFICATE)?|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[TEACHER_{n}]',
   priority: 80,
   severity: 'medium',
@@ -100,7 +100,7 @@ export const TEACHING_LICENSE: PIIPattern = {
  */
 export const AWS_CERTIFICATION: PIIPattern = {
   type: 'AWS_CERTIFICATION',
-  regex: /\bAWS[-\s]?(?:CERT(?:IFICATION)?|ID|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
+  regex: /\bAWS[\-\s]?(?:CERT(?:IFICATION)?|ID|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
   placeholder: '[AWS_CERT_{n}]',
   priority: 75,
   severity: 'low',
@@ -117,7 +117,7 @@ export const AWS_CERTIFICATION: PIIPattern = {
  */
 export const MICROSOFT_CERTIFICATION: PIIPattern = {
   type: 'MICROSOFT_CERTIFICATION',
-  regex: /\b(?:MICROSOFT|MCID|MS)[-\s]?(?:CERT(?:IFICATION)?|ID|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
+  regex: /\b(?:MICROSOFT|MCID|MS)[\-\s]?(?:CERT(?:IFICATION)?|ID|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
   placeholder: '[MS_CERT_{n}]',
   priority: 75,
   severity: 'low',
@@ -134,7 +134,7 @@ export const MICROSOFT_CERTIFICATION: PIIPattern = {
  */
 export const CISCO_CERTIFICATION: PIIPattern = {
   type: 'CISCO_CERTIFICATION',
-  regex: /\b(?:CISCO|CSCO)[-\s]?(?:CERT(?:IFICATION)?|ID|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
+  regex: /\b(?:CISCO|CSCO)[\-\s]?(?:CERT(?:IFICATION)?|ID|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
   placeholder: '[CISCO_CERT_{n}]',
   priority: 75,
   severity: 'low',
@@ -151,7 +151,7 @@ export const CISCO_CERTIFICATION: PIIPattern = {
  */
 export const COMPTIA_CERTIFICATION: PIIPattern = {
   type: 'COMPTIA_CERTIFICATION',
-  regex: /\bCOMPTIA[-\s]?(?:CERT(?:IFICATION)?|ID|NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
+  regex: /\bCOMPTIA[\-\s]?(?:CERT(?:IFICATION)?|ID|NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
   placeholder: '[COMPTIA_{n}]',
   priority: 75,
   severity: 'low',
@@ -168,7 +168,7 @@ export const COMPTIA_CERTIFICATION: PIIPattern = {
  */
 export const FINRA_LICENSE: PIIPattern = {
   type: 'FINRA_LICENSE',
-  regex: /\b(?:CRD|SERIES|FINRA)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{6,8})\b/gi,
+  regex: /\b(?:CRD|SERIES|FINRA)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{6,8})\b/gi,
   placeholder: '[FINRA_{n}]',
   priority: 85,
   severity: 'high',

--- a/packages/core/src/patterns/industries/real-estate.ts
+++ b/packages/core/src/patterns/industries/real-estate.ts
@@ -12,7 +12,7 @@ import { PIIPattern } from '../../types';
  */
 export const PROPERTY_PARCEL_NUMBER: PIIPattern = {
   type: 'PROPERTY_PARCEL_NUMBER',
-  regex: /\b(?:APN|PARCEL|ASSESSOR)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{3}[-\s]?\d{3}[-\s]?\d{3}(?:[-\s]?\d{1,3})?)\b/gi,
+  regex: /\b(?:APN|PARCEL|ASSESSOR)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{3}[\-\s]?\d{3}[\-\s]?\d{3}(?:[\-\s]?\d{1,3})?)\b/gi,
   placeholder: '[APN_{n}]',
   priority: 85,
   severity: 'high',
@@ -29,7 +29,7 @@ export const PROPERTY_PARCEL_NUMBER: PIIPattern = {
  */
 export const MLS_LISTING_NUMBER: PIIPattern = {
   type: 'MLS_LISTING_NUMBER',
-  regex: /\bMLS[-\s]?(?:NO|NUM|NUMBER|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\bMLS[\-\s]?(?:NO|NUM|NUMBER|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[MLS_{n}]',
   priority: 80,
   severity: 'medium',
@@ -46,7 +46,7 @@ export const MLS_LISTING_NUMBER: PIIPattern = {
  */
 export const MORTGAGE_LOAN_NUMBER: PIIPattern = {
   type: 'MORTGAGE_LOAN_NUMBER',
-  regex: /\b(?:MORTGAGE|LOAN|MTG)[-\s]?(?:NO|NUM|NUMBER|ID|ACCOUNT)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:MORTGAGE|LOAN|MTG)[\-\s]?(?:NO|NUM|NUMBER|ID|ACCOUNT)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[MORTGAGE_{n}]',
   priority: 90,
   severity: 'high',
@@ -63,7 +63,7 @@ export const MORTGAGE_LOAN_NUMBER: PIIPattern = {
  */
 export const PROPERTY_TAX_ACCOUNT: PIIPattern = {
   type: 'PROPERTY_TAX_ACCOUNT',
-  regex: /\b(?:PROPERTY[- ]?TAX|TAX|MUNICIPAL)[-\s]?(?:ACCOUNT|ACCT|NO|NUMBER|ID)?[-\s]?[:#]?\s*(\d{6,12})\b/gi,
+  regex: /\b(?:PROPERTY[- ]?TAX|TAX|MUNICIPAL)[\-\s]?(?:ACCOUNT|ACCT|NO|NUMBER|ID)?[\-\s]?[:#]?\s*(\d{6,12})\b/gi,
   placeholder: '[TAX_ACCT_{n}]',
   priority: 85,
   severity: 'high',
@@ -80,7 +80,7 @@ export const PROPERTY_TAX_ACCOUNT: PIIPattern = {
  */
 export const HOA_ACCOUNT_NUMBER: PIIPattern = {
   type: 'HOA_ACCOUNT_NUMBER',
-  regex: /\bHOA[-\s]?(?:ACCOUNT|ACCT|NO|NUMBER|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\bHOA[\-\s]?(?:ACCOUNT|ACCT|NO|NUMBER|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[HOA_{n}]',
   priority: 80,
   severity: 'medium',
@@ -97,7 +97,7 @@ export const HOA_ACCOUNT_NUMBER: PIIPattern = {
  */
 export const TITLE_DEED_NUMBER: PIIPattern = {
   type: 'TITLE_DEED_NUMBER',
-  regex: /\b(?:TITLE|DEED)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
+  regex: /\b(?:TITLE|DEED)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
   placeholder: '[DEED_{n}]',
   priority: 85,
   severity: 'high',
@@ -114,7 +114,7 @@ export const TITLE_DEED_NUMBER: PIIPattern = {
  */
 export const REAL_ESTATE_LICENSE: PIIPattern = {
   type: 'REAL_ESTATE_LICENSE',
-  regex: /\b(?:REAL[- ]?ESTATE|RE|BROKER)[-\s]?(?:LICENSE|LIC)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:REAL[- ]?ESTATE|RE|BROKER)[\-\s]?(?:LICENSE|LIC)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[RE_LIC_{n}]',
   priority: 80,
   severity: 'medium',
@@ -131,7 +131,7 @@ export const REAL_ESTATE_LICENSE: PIIPattern = {
  */
 export const APPRAISAL_REFERENCE: PIIPattern = {
   type: 'APPRAISAL_REFERENCE',
-  regex: /\b(?:APPRAISAL|APPR)[-\s]?(?:NO|NUM|NUMBER|REF|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:APPRAISAL|APPR)[\-\s]?(?:NO|NUM|NUMBER|REF|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[APPR_{n}]',
   priority: 75,
   severity: 'medium',
@@ -148,7 +148,7 @@ export const APPRAISAL_REFERENCE: PIIPattern = {
  */
 export const ESCROW_NUMBER: PIIPattern = {
   type: 'ESCROW_NUMBER',
-  regex: /\bESCROW[-\s]?(?:NO|NUM|NUMBER|ACCOUNT|ACCT|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\bESCROW[\-\s]?(?:NO|NUM|NUMBER|ACCOUNT|ACCT|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[ESCROW_{n}]',
   priority: 85,
   severity: 'high',
@@ -165,7 +165,7 @@ export const ESCROW_NUMBER: PIIPattern = {
  */
 export const LEASE_AGREEMENT_NUMBER: PIIPattern = {
   type: 'LEASE_AGREEMENT_NUMBER',
-  regex: /\b(?:LEASE|RENTAL)[-\s]?(?:AGREEMENT|CONTRACT|NO|NUM|NUMBER|ID)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:LEASE|RENTAL)[\-\s]?(?:AGREEMENT|CONTRACT|NO|NUM|NUMBER|ID)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[LEASE_{n}]',
   priority: 75,
   severity: 'medium',

--- a/packages/core/src/patterns/industries/retail.ts
+++ b/packages/core/src/patterns/industries/retail.ts
@@ -10,7 +10,7 @@ import { PIIPattern } from '../../types';
  */
 export const ORDER_NUMBER: PIIPattern = {
   type: 'ORDER_NUMBER',
-  regex: /\b(?:ORD(?:ER)?[-\s](?:NO|NUM(?:BER)?)?[-\s:#]?\s*|ORDER\s+(?:NO|NUM(?:BER)?)?[:\s]+)([A-Z0-9-]{8,14})\b/gi,
+  regex: /\b(?:ORD(?:ER)?[\-\s](?:NO|NUM(?:BER)?)?[\-\s:#]?\s*|ORDER\s+(?:NO|NUM(?:BER)?)?[:\s]+)([A-Z0-9-]{8,14})\b/gi,
   placeholder: '[ORDER_{n}]',
   priority: 90, // Higher priority than phones (85) to match "ORD-1234567890" correctly
   severity: 'medium',
@@ -26,7 +26,7 @@ export const ORDER_NUMBER: PIIPattern = {
  */
 export const LOYALTY_CARD_NUMBER: PIIPattern = {
   type: 'LOYALTY_CARD_NUMBER',
-  regex: /\bLOYALTY[-\s]?(?:CARD)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*(\d{10,16})\b/gi,
+  regex: /\bLOYALTY[\-\s]?(?:CARD)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*(\d{10,16})\b/gi,
   placeholder: '[LOYALTY_{n}]',
   priority: 80,
   severity: 'medium',
@@ -41,7 +41,7 @@ export const LOYALTY_CARD_NUMBER: PIIPattern = {
  */
 export const CUSTOMER_ID: PIIPattern = {
   type: 'CUSTOMER_ID',
-  regex: /\b(?:CUSTOMER|CUST)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
+  regex: /\b(?:CUSTOMER|CUST)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
   placeholder: '[CUSTOMER_{n}]',
   priority: 85,
   severity: 'high',
@@ -68,7 +68,7 @@ export const DEVICE_ID_TAG: PIIPattern = {
  */
 export const GIFT_CARD_NUMBER: PIIPattern = {
   type: 'GIFT_CARD_NUMBER',
-  regex: /\b(?:GIFT[-\s]?CARD|GC)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*(\d{12,19})\b/gi,
+  regex: /\b(?:GIFT[\-\s]?CARD|GC)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*(\d{12,19})\b/gi,
   placeholder: '[GIFTCARD_{n}]',
   priority: 85,
   severity: 'high',
@@ -83,7 +83,7 @@ export const GIFT_CARD_NUMBER: PIIPattern = {
  */
 export const RMA_NUMBER: PIIPattern = {
   type: 'RMA_NUMBER',
-  regex: /\b(?:RMA|RETURN)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:RMA|RETURN)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[RMA_{n}]',
   priority: 80,
   severity: 'medium',
@@ -98,7 +98,7 @@ export const RMA_NUMBER: PIIPattern = {
  */
 export const SHIPPING_TRACKING: PIIPattern = {
   type: 'SHIPPING_TRACKING',
-  regex: /\b(?:TRACKING|TRACK)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{10,30})\b/gi,
+  regex: /\b(?:TRACKING|TRACK)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{10,30})\b/gi,
   placeholder: '[TRACKING_{n}]',
   priority: 75,
   severity: 'medium',
@@ -113,7 +113,7 @@ export const SHIPPING_TRACKING: PIIPattern = {
  */
 export const INVOICE_NUMBER: PIIPattern = {
   type: 'INVOICE_NUMBER',
-  regex: /\b(?:INVOICE|INV)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
+  regex: /\b(?:INVOICE|INV)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,14})\b/gi,
   placeholder: '[INVOICE_{n}]',
   priority: 80,
   severity: 'medium',
@@ -128,7 +128,7 @@ export const INVOICE_NUMBER: PIIPattern = {
  */
 export const CART_SESSION_ID: PIIPattern = {
   type: 'CART_SESSION_ID',
-  regex: /\b(?:CART|SESSION)[-\s]?(?:ID)?[-\s]?[:#]?\s*([a-f0-9]{32,64})\b/gi,
+  regex: /\b(?:CART|SESSION)[\-\s]?(?:ID)?[\-\s]?[:#]?\s*([a-f0-9]{32,64})\b/gi,
   placeholder: '[CART_{n}]',
   priority: 70,
   severity: 'low',
@@ -143,7 +143,7 @@ export const CART_SESSION_ID: PIIPattern = {
  */
 export const PROMO_CODE: PIIPattern = {
   type: 'PROMO_CODE',
-  regex: /\b(?:PROMO|COUPON|DISCOUNT)[-\s]?(?:CODE)?[-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
+  regex: /\b(?:PROMO|COUPON|DISCOUNT)[\-\s]?(?:CODE)?[\-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
   placeholder: '[PROMO_{n}]',
   priority: 65,
   severity: 'low',
@@ -158,7 +158,7 @@ export const PROMO_CODE: PIIPattern = {
  */
 export const WISHLIST_ID: PIIPattern = {
   type: 'WISHLIST_ID',
-  regex: /\b(?:WISHLIST|WISH[-\s]?LIST)[-\s]?(?:ID)?[-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
+  regex: /\b(?:WISHLIST|WISH[\-\s]?LIST)[\-\s]?(?:ID)?[\-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
   placeholder: '[WISHLIST_{n}]',
   priority: 70,
   severity: 'low',
@@ -173,7 +173,7 @@ export const WISHLIST_ID: PIIPattern = {
  */
 export const PRODUCT_SKU: PIIPattern = {
   type: 'PRODUCT_SKU',
-  regex: /\bSKU[-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
+  regex: /\bSKU[\-\s]?[:#]?\s*([A-Z0-9]{6,16})\b/gi,
   placeholder: '[SKU_{n}]',
   priority: 60,
   severity: 'low',

--- a/packages/core/src/patterns/industries/telecoms.ts
+++ b/packages/core/src/patterns/industries/telecoms.ts
@@ -10,7 +10,7 @@ import { PIIPattern } from '../../types';
  */
 export const TELECOMS_ACCOUNT_NUMBER: PIIPattern = {
   type: 'TELECOMS_ACCOUNT_NUMBER',
-  regex: /\bACC(?:OUNT)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*(\d{8,12})\b/gi,
+  regex: /\bACC(?:OUNT)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*(\d{8,12})\b/gi,
   placeholder: '[ACCOUNT_{n}]',
   priority: 90,
   severity: 'high',
@@ -25,7 +25,7 @@ export const TELECOMS_ACCOUNT_NUMBER: PIIPattern = {
  */
 export const METER_SERIAL_NUMBER: PIIPattern = {
   type: 'METER_SERIAL_NUMBER',
-  regex: /\bMTR[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*(\d{8,12})\b/gi,
+  regex: /\bMTR[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*(\d{8,12})\b/gi,
   placeholder: '[METER_{n}]',
   priority: 85,
   severity: 'high',
@@ -37,7 +37,7 @@ export const METER_SERIAL_NUMBER: PIIPattern = {
  */
 export const IMSI_NUMBER: PIIPattern = {
   type: 'IMSI_NUMBER',
-  regex: /\bIMSI[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*(\d{15})\b/gi,
+  regex: /\bIMSI[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*(\d{15})\b/gi,
   placeholder: '[IMSI_{n}]',
   priority: 90,
   severity: 'high',
@@ -49,7 +49,7 @@ export const IMSI_NUMBER: PIIPattern = {
  */
 export const IMEI_NUMBER: PIIPattern = {
   type: 'IMEI_NUMBER',
-  regex: /\bIMEI[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*(\d{15})\b/gi,
+  regex: /\bIMEI[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*(\d{15})\b/gi,
   placeholder: '[IMEI_{n}]',
   priority: 90,
   severity: 'high',
@@ -61,7 +61,7 @@ export const IMEI_NUMBER: PIIPattern = {
  */
 export const SIM_CARD_NUMBER: PIIPattern = {
   type: 'SIM_CARD_NUMBER',
-  regex: /\bSIM[-\s]?(?:CARD)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*(\d{19,20})\b/gi,
+  regex: /\bSIM[\-\s]?(?:CARD)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*(\d{19,20})\b/gi,
   placeholder: '[SIM_{n}]',
   priority: 85,
   severity: 'high',
@@ -76,7 +76,7 @@ export const SIM_CARD_NUMBER: PIIPattern = {
  */
 export const SERVICE_REQUEST_NUMBER: PIIPattern = {
   type: 'SERVICE_REQUEST_NUMBER',
-  regex: /\b(?:SERVICE|SR)[-\s]?(?:REQUEST)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:SERVICE|SR)[\-\s]?(?:REQUEST)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[SERVICE_{n}]',
   priority: 80,
   severity: 'medium',
@@ -91,7 +91,7 @@ export const SERVICE_REQUEST_NUMBER: PIIPattern = {
  */
 export const UTILITY_BILL_ACCOUNT: PIIPattern = {
   type: 'UTILITY_BILL_ACCOUNT',
-  regex: /\b(?:BILL|BILLING)[-\s]?(?:ACCOUNT)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*(\d{8,14})\b/gi,
+  regex: /\b(?:BILL|BILLING)[\-\s]?(?:ACCOUNT)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*(\d{8,14})\b/gi,
   placeholder: '[BILL_{n}]',
   priority: 85,
   severity: 'high',
@@ -106,7 +106,7 @@ export const UTILITY_BILL_ACCOUNT: PIIPattern = {
  */
 export const INSTALLATION_REF: PIIPattern = {
   type: 'INSTALLATION_REF',
-  regex: /\b(?:INSTALLATION|INSTALL)[-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:INSTALLATION|INSTALL)[\-\s]?(?:REF(?:ERENCE)?|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[INSTALL_{n}]',
   priority: 75,
   severity: 'medium',
@@ -121,7 +121,7 @@ export const INSTALLATION_REF: PIIPattern = {
  */
 export const PHONE_LINE_NUMBER: PIIPattern = {
   type: 'PHONE_LINE_NUMBER',
-  regex: /\b(?:LINE|NUMBER)[-\s]?(?:NO)?[-\s]?[:#]?\s*(\d{3}[-\s]?\d{3}[-\s]?\d{4})\b/g,
+  regex: /\b(?:LINE|NUMBER)[\-\s]?(?:NO)?[\-\s]?[:#]?\s*(\d{3}[\-\s]?\d{3}[\-\s]?\d{4})\b/g,
   placeholder: '[PHONE_{n}]',
   priority: 90,
   severity: 'high',
@@ -136,7 +136,7 @@ export const PHONE_LINE_NUMBER: PIIPattern = {
  */
 export const BROADBAND_SERVICE_ID: PIIPattern = {
   type: 'BROADBAND_SERVICE_ID',
-  regex: /\b(?:BROADBAND|INTERNET|ISP)[-\s]?(?:SERVICE)?[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
+  regex: /\b(?:BROADBAND|INTERNET|ISP)[\-\s]?(?:SERVICE)?[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
   placeholder: '[BROADBAND_{n}]',
   priority: 80,
   severity: 'high',
@@ -151,7 +151,7 @@ export const BROADBAND_SERVICE_ID: PIIPattern = {
  */
 export const EQUIPMENT_SERIAL: PIIPattern = {
   type: 'EQUIPMENT_SERIAL',
-  regex: /\b(?:EQUIPMENT|DEVICE|ROUTER|MODEM)[-\s]?(?:SERIAL)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{10,16})\b/gi,
+  regex: /\b(?:EQUIPMENT|DEVICE|ROUTER|MODEM)[\-\s]?(?:SERIAL)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{10,16})\b/gi,
   placeholder: '[EQUIPMENT_{n}]',
   priority: 75,
   severity: 'medium',
@@ -166,7 +166,7 @@ export const EQUIPMENT_SERIAL: PIIPattern = {
  */
 export const SMART_METER_ID: PIIPattern = {
   type: 'SMART_METER_ID',
-  regex: /\b(?:SMART[-\s]?METER)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{10,16})\b/gi,
+  regex: /\b(?:SMART[\-\s]?METER)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{10,16})\b/gi,
   placeholder: '[SMART_METER_{n}]',
   priority: 85,
   severity: 'high',

--- a/packages/core/src/patterns/industries/transportation.ts
+++ b/packages/core/src/patterns/industries/transportation.ts
@@ -11,7 +11,7 @@ import { PIIPattern } from '../../types';
  */
 export const VIN: PIIPattern = {
   type: 'VIN',
-  regex: /\bVIN[-\s]?[:#]?\s*([A-HJ-NPR-Z0-9]{17})\b/gi,
+  regex: /\bVIN[\-\s]?[:#]?\s*([A-HJ-NPR-Z0-9]{17})\b/gi,
   placeholder: '[VIN_{n}]',
   priority: 90,
   severity: 'high',
@@ -27,7 +27,7 @@ export const VIN: PIIPattern = {
  */
 export const LICENSE_PLATE: PIIPattern = {
   type: 'LICENSE_PLATE',
-  regex: /\b(?:LICENSE|PLATE|REG(?:ISTRATION)?)[-\s]?(?:NO|NUM(?:BER)?|PLATE)?[-\s]?[:#]?\s*([A-Z0-9]{2,8})\b/gi,
+  regex: /\b(?:LICENSE|PLATE|REG(?:ISTRATION)?)[\-\s]?(?:NO|NUM(?:BER)?|PLATE)?[\-\s]?[:#]?\s*([A-Z0-9]{2,8})\b/gi,
   placeholder: '[PLATE_{n}]',
   priority: 85,
   severity: 'high',
@@ -42,7 +42,7 @@ export const LICENSE_PLATE: PIIPattern = {
  */
 export const FLEET_VEHICLE_ID: PIIPattern = {
   type: 'FLEET_VEHICLE_ID',
-  regex: /\b(?:FLEET|VEHICLE)[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:FLEET|VEHICLE)[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[FLEET_{n}]',
   priority: 80,
   severity: 'medium',
@@ -57,7 +57,7 @@ export const FLEET_VEHICLE_ID: PIIPattern = {
  */
 export const TELEMATICS_DEVICE_ID: PIIPattern = {
   type: 'TELEMATICS_DEVICE_ID',
-  regex: /\b(?:TELEMATICS|GPS[-\s]?DEVICE)[-\s]?(?:ID)?[-\s]?[:#]?\s*([A-Z0-9]{10,16})\b/gi,
+  regex: /\b(?:TELEMATICS|GPS[\-\s]?DEVICE)[\-\s]?(?:ID)?[\-\s]?[:#]?\s*([A-Z0-9]{10,16})\b/gi,
   placeholder: '[TELEMATICS_{n}]',
   priority: 80,
   severity: 'medium',
@@ -72,7 +72,7 @@ export const TELEMATICS_DEVICE_ID: PIIPattern = {
  */
 export const BOOKING_NUMBER: PIIPattern = {
   type: 'BOOKING_NUMBER',
-  regex: /\b(?:BOOKING|RESERVATION|RES)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\b(?:BOOKING|RESERVATION|RES)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[BOOKING_{n}]',
   priority: 80,
   severity: 'medium',
@@ -87,7 +87,7 @@ export const BOOKING_NUMBER: PIIPattern = {
  */
 export const DRIVER_ID: PIIPattern = {
   type: 'DRIVER_ID',
-  regex: /\bDRIVER[-\s]?(?:ID|NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
+  regex: /\bDRIVER[\-\s]?(?:ID|NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{6,12})\b/gi,
   placeholder: '[DRIVER_{n}]',
   priority: 85,
   severity: 'high',
@@ -102,7 +102,7 @@ export const DRIVER_ID: PIIPattern = {
  */
 export const SHIPMENT_TRACKING: PIIPattern = {
   type: 'SHIPMENT_TRACKING',
-  regex: /\b(?:SHIPMENT|TRACKING)[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{10,30})\b/gi,
+  regex: /\b(?:SHIPMENT|TRACKING)[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{10,30})\b/gi,
   placeholder: '[SHIPMENT_{n}]',
   priority: 75,
   severity: 'medium',
@@ -117,7 +117,7 @@ export const SHIPMENT_TRACKING: PIIPattern = {
  */
 export const TOLL_TAG_ID: PIIPattern = {
   type: 'TOLL_TAG_ID',
-  regex: /\b(?:TOLL[-\s]?TAG|E[-]?ZPASS|TRANSPONDER)[-\s]?(?:ID)?[-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
+  regex: /\b(?:TOLL[\-\s]?TAG|E[-]?ZPASS|TRANSPONDER)[\-\s]?(?:ID)?[\-\s]?[:#]?\s*([A-Z0-9]{8,16})\b/gi,
   placeholder: '[TOLL_{n}]',
   priority: 80,
   severity: 'medium',
@@ -132,7 +132,7 @@ export const TOLL_TAG_ID: PIIPattern = {
  */
 export const INSPECTION_CERTIFICATE: PIIPattern = {
   type: 'INSPECTION_CERTIFICATE',
-  regex: /\b(?:INSPECTION|INSP)[-\s]?(?:CERT(?:IFICATE)?)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
+  regex: /\b(?:INSPECTION|INSP)[\-\s]?(?:CERT(?:IFICATE)?)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z0-9]{8,14})\b/gi,
   placeholder: '[INSPECTION_{n}]',
   priority: 75,
   severity: 'medium',
@@ -147,7 +147,7 @@ export const INSPECTION_CERTIFICATE: PIIPattern = {
  */
 export const ODOMETER_READING_REF: PIIPattern = {
   type: 'ODOMETER_READING_REF',
-  regex: /\b(?:ODOMETER|MILEAGE)[-\s]?[:#]?\s*(\d{1,7})\s*(?:KM|MILES|MI)\b/gi,
+  regex: /\b(?:ODOMETER|MILEAGE)[\-\s]?[:#]?\s*(\d{1,7})\s*(?:KM|MILES|MI)\b/gi,
   placeholder: '[ODO_{n}]',
   priority: 70,
   severity: 'low',
@@ -162,7 +162,7 @@ export const ODOMETER_READING_REF: PIIPattern = {
  */
 export const VEHICLE_INSURANCE_POLICY: PIIPattern = {
   type: 'VEHICLE_INSURANCE_POLICY',
-  regex: /\b(?:AUTO|VEHICLE|CAR)[-\s]?(?:INSURANCE)?[-\s]?(?:POLICY)?[-\s]?(?:NO|NUM(?:BER)?)?[-\s]?[:#]?\s*([A-Z]{2,4}\d{6,10})\b/gi,
+  regex: /\b(?:AUTO|VEHICLE|CAR)[\-\s]?(?:INSURANCE)?[\-\s]?(?:POLICY)?[\-\s]?(?:NO|NUM(?:BER)?)?[\-\s]?[:#]?\s*([A-Z]{2,4}\d{6,10})\b/gi,
   placeholder: '[AUTO_POLICY_{n}]',
   priority: 85,
   severity: 'high',
@@ -177,7 +177,7 @@ export const VEHICLE_INSURANCE_POLICY: PIIPattern = {
  */
 export const TRIP_ID: PIIPattern = {
   type: 'TRIP_ID',
-  regex: /\b(?:TRIP|RIDE)[-\s]?(?:ID)?[-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
+  regex: /\b(?:TRIP|RIDE)[\-\s]?(?:ID)?[\-\s]?[:#]?\s*([A-Z0-9]{8,20})\b/gi,
   placeholder: '[TRIP_{n}]',
   priority: 80,
   severity: 'medium',

--- a/packages/core/src/patterns/industries/vehicles.ts
+++ b/packages/core/src/patterns/industries/vehicles.ts
@@ -11,14 +11,14 @@ import type { PIIPattern } from '../../types';
  */
 export const VIN_NUMBER: PIIPattern = {
   type: 'VIN_NUMBER',
-  regex: /\bVIN[-\s\u00A0]?(?:NO|NUM|NUMBER)?[-\s\u00A0]?[:#]?\s*([A-HJ-NPR-Z0-9]{17})\b/gi,
+  regex: /\bVIN[\-\s\u00A0]?(?:NO|NUM|NUMBER)?[\-\s\u00A0]?[:#]?\s*([A-HJ-NPR-Z0-9]{17})\b/gi,
   placeholder: '[VIN_{n}]',
   priority: 85,
   severity: 'medium',
   description: 'Vehicle Identification Number (VIN)',
   validator: (value: string, context: string) => {
     // Normalize separators (VINs typically don't have separators, but handle if present)
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '').toUpperCase();
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '').toUpperCase();
     
     // Must be exactly 17 characters after normalization
     if (cleaned.length !== 17) return false;
@@ -37,7 +37,7 @@ export const VIN_NUMBER: PIIPattern = {
  */
 export const US_LICENSE_PLATE: PIIPattern = {
   type: 'US_LICENSE_PLATE',
-  regex: /\b(?:PLATE|LICENSE|TAG)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{3,8})\b/gi,
+  regex: /\b(?:PLATE|LICENSE|TAG)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{3,8})\b/gi,
   placeholder: '[PLATE_{n}]',
   priority: 75,
   severity: 'medium',
@@ -880,7 +880,7 @@ export const UK_LICENSE_PLATE: PIIPattern = {
  */
 export const GERMAN_LICENSE_PLATE: PIIPattern = {
   type: 'GERMAN_LICENSE_PLATE',
-  regex: /\b([A-ZÄÖÜ]{1,3}[-\s][A-ZÄÖÜ]{1,2}\s?\d{1,4})\b/gi,
+  regex: /\b([A-ZÄÖÜ]{1,3}[\-\s][A-ZÄÖÜ]{1,2}\s?\d{1,4})\b/gi,
   placeholder: '[DE_PLATE_{n}]',
   priority: 85,
   severity: 'medium',
@@ -912,7 +912,7 @@ export const FRENCH_LICENSE_PLATE: PIIPattern = {
  */
 export const CANADIAN_LICENSE_PLATE: PIIPattern = {
   type: 'CANADIAN_LICENSE_PLATE',
-  regex: /\b([A-Z]{3,4}[-\s]?\d{3,4})\b/g,
+  regex: /\b([A-Z]{3,4}[\-\s]?\d{3,4})\b/g,
   placeholder: '[CA_PLATE_{n}]',
   priority: 80,
   severity: 'medium',
@@ -928,7 +928,7 @@ export const CANADIAN_LICENSE_PLATE: PIIPattern = {
  */
 export const AUSTRALIAN_LICENSE_PLATE: PIIPattern = {
   type: 'AUSTRALIAN_LICENSE_PLATE',
-  regex: /\b([A-Z]{2,3}[-\s]?\d{2,4})\b/g,
+  regex: /\b([A-Z]{2,3}[\-\s]?\d{2,4})\b/g,
   placeholder: '[AU_PLATE_{n}]',
   priority: 80,
   severity: 'medium',
@@ -960,7 +960,7 @@ export const JAPANESE_LICENSE_PLATE: PIIPattern = {
  */
 export const INTERNATIONAL_LICENSE_PLATE: PIIPattern = {
   type: 'INTERNATIONAL_LICENSE_PLATE',
-  regex: /\b(?:PLATE|REGISTRATION|TAG)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z0-9]{4,10})\b/gi,
+  regex: /\b(?:PLATE|REGISTRATION|TAG)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z0-9]{4,10})\b/gi,
   placeholder: '[PLATE_{n}]',
   priority: 70,
   severity: 'medium',

--- a/packages/core/src/patterns/international.ts
+++ b/packages/core/src/patterns/international.ts
@@ -27,7 +27,7 @@ export const GERMAN_TAX_ID: PIIPattern = {
   description: 'German Tax Identification Number (Steueridentifikationsnummer)',
   validator: (value: string, context: string) => {
     // Normalize separators
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
     
     // Must be exactly 11 digits after normalization
     if (!/^\d{11}$/.test(cleaned)) return false;
@@ -86,13 +86,13 @@ export const FRENCH_SOCIAL_SECURITY: PIIPattern = {
  */
 export const SPANISH_DNI: PIIPattern = {
   type: 'SPANISH_DNI',
-  regex: /\b([0-9]{8}[-\s]?[A-Z]|[XYZ][-\s]?[0-9]{7}[-\s]?[A-Z])\b/gi,
+  regex: /\b([0-9]{8}[\-\s]?[A-Z]|[XYZ][\-\s]?[0-9]{7}[\-\s]?[A-Z])\b/gi,
   placeholder: '[ES_DNI_{n}]',
   priority: 90,
   severity: 'high',
   description: 'Spanish National ID (DNI) or Foreigner ID (NIE)',
   validator: (value: string, _context: string) => {
-    const cleaned = value.replace(/[-\s]/g, '').toUpperCase();
+    const cleaned = value.replace(/[\-\s]/g, '').toUpperCase();
     const letters = 'TRWAGMYFPDXBNJZSQVHLCKE';
 
     let numbers: string;
@@ -180,7 +180,7 @@ export const DUTCH_BSN: PIIPattern = {
   description: 'Dutch Citizen Service Number (BSN)',
   validator: (value: string, context: string) => {
     // Normalize separators
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
     
     // Must be exactly 9 digits after normalization
     if (!/^\d{9}$/.test(cleaned)) return false;
@@ -214,7 +214,7 @@ export const POLISH_PESEL: PIIPattern = {
   description: 'Polish National Identification Number (PESEL)',
   validator: (value: string, context: string) => {
     // Normalize separators
-    const cleaned = value.replace(/[\s\u00A0.-]/g, '');
+    const cleaned = value.replace(/[\s\u00A0.\-]/g, '');
     
     // Must be exactly 11 digits after normalization
     if (!/^\d{11}$/.test(cleaned)) return false;
@@ -407,13 +407,13 @@ export const JAPANESE_MY_NUMBER: PIIPattern = {
  */
 export const SOUTH_KOREAN_RRN: PIIPattern = {
   type: 'SOUTH_KOREAN_RRN',
-  regex: /\b(\d{6}[-\s]?[1-4]\d{6})\b/g,
+  regex: /\b(\d{6}[\-\s]?[1-4]\d{6})\b/g,
   placeholder: '[KR_RRN_{n}]',
   priority: 95,
   severity: 'high',
   description: 'South Korean Resident Registration Number',
   validator: (value: string, context: string) => {
-    const cleaned = value.replace(/[-\s]/g, '');
+    const cleaned = value.replace(/[\-\s]/g, '');
 
     // Must be in Korean context
     const relevantContext = /rrn|korean|korea|주민등록번호/i.test(context);
@@ -445,13 +445,13 @@ export const SOUTH_KOREAN_RRN: PIIPattern = {
  */
 export const CANADIAN_SIN: PIIPattern = {
   type: 'CANADIAN_SIN',
-  regex: /\b(\d{3}[-\s]?\d{3}[-\s]?\d{3})\b/g,
+  regex: /\b(\d{3}[\-\s]?\d{3}[\-\s]?\d{3})\b/g,
   placeholder: '[CA_SIN_{n}]',
   priority: 95,
   severity: 'high',
   description: 'Canadian Social Insurance Number',
   validator: (value: string, context: string) => {
-    const cleaned = value.replace(/[-\s]/g, '');
+    const cleaned = value.replace(/[\-\s]/g, '');
 
     // Must be in Canadian context
     const relevantContext = /sin|social.insurance|canadian|canada/i.test(context);

--- a/packages/core/src/patterns/international/africa.ts
+++ b/packages/core/src/patterns/international/africa.ts
@@ -66,7 +66,7 @@ export const NIGERIA_NIN: PIIPattern = {
  */
 export const NIGERIA_BVN: PIIPattern = {
   type: 'NIGERIA_BVN',
-  regex: /\bBVN[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{11})\b/gi,
+  regex: /\bBVN[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{11})\b/gi,
   placeholder: '[NG_BVN_{n}]',
   priority: 90,
   severity: 'high',
@@ -185,7 +185,7 @@ export const GHANA_CARD: PIIPattern = {
  */
 export const MOROCCO_NATIONAL_ID: PIIPattern = {
   type: 'MOROCCO_NATIONAL_ID',
-  regex: /\b(?:CNIE|ID)[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*([A-Z]{1,2}\d{6,8}|\d{8})\b/gi,
+  regex: /\b(?:CNIE|ID)[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*([A-Z]{1,2}\d{6,8}|\d{8})\b/gi,
   placeholder: '[MA_ID_{n}]',
   priority: 85,
   severity: 'high',

--- a/packages/core/src/patterns/international/central-asia.ts
+++ b/packages/core/src/patterns/international/central-asia.ts
@@ -11,7 +11,7 @@ import type { PIIPattern } from '../../types';
  */
 export const KAZAKHSTAN_IIN: PIIPattern = {
   type: 'KAZAKHSTAN_IIN',
-  regex: /\bIIN[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{12})\b/gi,
+  regex: /\bIIN[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{12})\b/gi,
   placeholder: '[KZ_IIN_{n}]',
   priority: 90,
   severity: 'high',
@@ -55,7 +55,7 @@ export const UZBEKISTAN_PASSPORT: PIIPattern = {
  */
 export const UZBEKISTAN_STIR: PIIPattern = {
   type: 'UZBEKISTAN_STIR',
-  regex: /\bSTIR[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{9})\b/gi,
+  regex: /\bSTIR[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{9})\b/gi,
   placeholder: '[UZ_STIR_{n}]',
   priority: 90,
   severity: 'high',
@@ -73,7 +73,7 @@ export const UZBEKISTAN_STIR: PIIPattern = {
  */
 export const KYRGYZSTAN_PIN: PIIPattern = {
   type: 'KYRGYZSTAN_PIN',
-  regex: /\bPIN[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{14})\b/gi,
+  regex: /\bPIN[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{14})\b/gi,
   placeholder: '[KG_PIN_{n}]',
   priority: 90,
   severity: 'high',
@@ -91,7 +91,7 @@ export const KYRGYZSTAN_PIN: PIIPattern = {
  */
 export const TAJIKISTAN_NATIONAL_ID: PIIPattern = {
   type: 'TAJIKISTAN_NATIONAL_ID',
-  regex: /\b(?:TAJIK|TJ)[-\s]?(?:ID|NATIONAL\s?ID)[-\s]?[:#]?\s*(\d{9,10})\b/gi,
+  regex: /\b(?:TAJIK|TJ)[\-\s]?(?:ID|NATIONAL\s?ID)[\-\s]?[:#]?\s*(\d{9,10})\b/gi,
   placeholder: '[TJ_ID_{n}]',
   priority: 85,
   severity: 'high',

--- a/packages/core/src/patterns/international/eastern-europe.ts
+++ b/packages/core/src/patterns/international/eastern-europe.ts
@@ -36,7 +36,7 @@ export const RUSSIAN_SNILS: PIIPattern = {
   severity: 'high',
   description: 'Russian SNILS (Pension Fund Number)',
   validator: (value: string, context: string) => {
-    const digits = value.replace(/[-\s]/g, '');
+    const digits = value.replace(/[\-\s]/g, '');
     if (digits.length !== 11) return false;
 
     return /russia|russian|snils|снилс|pension|пенсионный/i.test(context);
@@ -67,7 +67,7 @@ export const UKRAINIAN_PASSPORT: PIIPattern = {
  */
 export const UKRAINIAN_INN: PIIPattern = {
   type: 'UKRAINIAN_INN',
-  regex: /\bINN[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{10})\b/gi,
+  regex: /\bINN[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{10})\b/gi,
   placeholder: '[UA_INN_{n}]',
   priority: 90,
   severity: 'high',
@@ -118,7 +118,7 @@ export const CZECH_NATIONAL_ID: PIIPattern = {
  */
 export const ROMANIAN_CNP: PIIPattern = {
   type: 'ROMANIAN_CNP',
-  regex: /\bCNP[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{13})\b/gi,
+  regex: /\bCNP[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{13})\b/gi,
   placeholder: '[RO_CNP_{n}]',
   priority: 95,
   severity: 'high',

--- a/packages/core/src/patterns/international/latin-america.ts
+++ b/packages/core/src/patterns/international/latin-america.ts
@@ -88,7 +88,7 @@ export const CHILE_RUT: PIIPattern = {
  */
 export const COLOMBIA_CEDULA: PIIPattern = {
   type: 'COLOMBIA_CEDULA',
-  regex: /\b(?:CC|CÉDULA|CEDULA)[-\s]?(?:NO|NUM)?[-\s]?[:#]?\s*(\d{6,10})\b/gi,
+  regex: /\b(?:CC|CÉDULA|CEDULA)[\-\s]?(?:NO|NUM)?[\-\s]?[:#]?\s*(\d{6,10})\b/gi,
   placeholder: '[CO_CC_{n}]',
   priority: 90,
   severity: 'high',
@@ -107,7 +107,7 @@ export const COLOMBIA_CEDULA: PIIPattern = {
  */
 export const COLOMBIA_NIT: PIIPattern = {
   type: 'COLOMBIA_NIT',
-  regex: /\bNIT[-\s]?(?:NO|NUM)?[-\s]?[:#]?\s*(\d{9}-\d{1})\b/gi,
+  regex: /\bNIT[\-\s]?(?:NO|NUM)?[\-\s]?[:#]?\s*(\d{9}-\d{1})\b/gi,
   placeholder: '[CO_NIT_{n}]',
   priority: 85,
   severity: 'high',
@@ -144,7 +144,7 @@ export const PERU_DNI: PIIPattern = {
  */
 export const PERU_RUC: PIIPattern = {
   type: 'PERU_RUC',
-  regex: /\bRUC[-\s]?(?:NO|NUM)?[-\s]?[:#]?\s*(\d{11})\b/gi,
+  regex: /\bRUC[\-\s]?(?:NO|NUM)?[\-\s]?[:#]?\s*(\d{11})\b/gi,
   placeholder: '[PE_RUC_{n}]',
   priority: 90,
   severity: 'high',

--- a/packages/core/src/patterns/international/middle-east.ts
+++ b/packages/core/src/patterns/international/middle-east.ts
@@ -12,7 +12,7 @@ import { PIIPattern } from '../../types';
  */
 export const UAE_EMIRATES_ID: PIIPattern = {
   type: 'UAE_EMIRATES_ID',
-  regex: /\b(784[-\s]?\d{4}[-\s]?\d{7}[-\s]?\d)\b/g,
+  regex: /\b(784[\-\s]?\d{4}[\-\s]?\d{7}[\-\s]?\d)\b/g,
   placeholder: '[UAE_ID_{n}]',
   priority: 95,
   severity: 'high',

--- a/packages/core/src/patterns/international/oceania.ts
+++ b/packages/core/src/patterns/international/oceania.ts
@@ -29,7 +29,7 @@ export const NEW_ZEALAND_DRIVER_LICENSE: PIIPattern = {
  */
 export const NEW_ZEALAND_IRD: PIIPattern = {
   type: 'NEW_ZEALAND_IRD',
-  regex: /\bIRD[-\s]?(?:NO|NUM|NUMBER)?[-\s]?[:#]?\s*(\d{8,9})\b/gi,
+  regex: /\bIRD[\-\s]?(?:NO|NUM|NUMBER)?[\-\s]?[:#]?\s*(\d{8,9})\b/gi,
   placeholder: '[NZ_IRD_{n}]',
   priority: 90,
   severity: 'high',
@@ -66,7 +66,7 @@ export const NEW_ZEALAND_PASSPORT: PIIPattern = {
  */
 export const FIJI_NATIONAL_ID: PIIPattern = {
   type: 'FIJI_NATIONAL_ID',
-  regex: /\b(?:FIJI|FJ)[-\s]?(?:ID|NATIONAL\s?ID)[-\s]?[:#]?\s*([A-Z0-9]{8,10})\b/gi,
+  regex: /\b(?:FIJI|FJ)[\-\s]?(?:ID|NATIONAL\s?ID)[\-\s]?[:#]?\s*([A-Z0-9]{8,10})\b/gi,
   placeholder: '[FJ_ID_{n}]',
   priority: 85,
   severity: 'high',
@@ -82,7 +82,7 @@ export const FIJI_NATIONAL_ID: PIIPattern = {
  */
 export const PNG_NATIONAL_ID: PIIPattern = {
   type: 'PNG_NATIONAL_ID',
-  regex: /\b(?:PNG|PAPUA)[-\s]?(?:ID|NATIONAL\s?ID)[-\s]?[:#]?\s*([A-Z0-9]{8,12})\b/gi,
+  regex: /\b(?:PNG|PAPUA)[\-\s]?(?:ID|NATIONAL\s?ID)[\-\s]?[:#]?\s*([A-Z0-9]{8,12})\b/gi,
   placeholder: '[PNG_ID_{n}]',
   priority: 85,
   severity: 'high',
@@ -98,7 +98,7 @@ export const PNG_NATIONAL_ID: PIIPattern = {
  */
 export const SAMOA_NATIONAL_ID: PIIPattern = {
   type: 'SAMOA_NATIONAL_ID',
-  regex: /\b(?:SAMOA|WS)[-\s]?(?:ID|NATIONAL\s?ID)[-\s]?[:#]?\s*(\d{8,10})\b/gi,
+  regex: /\b(?:SAMOA|WS)[\-\s]?(?:ID|NATIONAL\s?ID)[\-\s]?[:#]?\s*(\d{8,10})\b/gi,
   placeholder: '[WS_ID_{n}]',
   priority: 85,
   severity: 'high',
@@ -114,7 +114,7 @@ export const SAMOA_NATIONAL_ID: PIIPattern = {
  */
 export const TONGA_NATIONAL_ID: PIIPattern = {
   type: 'TONGA_NATIONAL_ID',
-  regex: /\b(?:TONGA|TO)[-\s]?(?:ID|NATIONAL\s?ID)[-\s]?[:#]?\s*([A-Z0-9]{8,10})\b/gi,
+  regex: /\b(?:TONGA|TO)[\-\s]?(?:ID|NATIONAL\s?ID)[\-\s]?[:#]?\s*([A-Z0-9]{8,10})\b/gi,
   placeholder: '[TO_ID_{n}]',
   priority: 85,
   severity: 'high',

--- a/packages/core/src/patterns/international/southeast-asia.ts
+++ b/packages/core/src/patterns/international/southeast-asia.ts
@@ -84,13 +84,13 @@ export const THAILAND_NATIONAL_ID: PIIPattern = {
  */
 export const MALAYSIA_MYKAD: PIIPattern = {
   type: 'MALAYSIA_MYKAD',
-  regex: /\b(\d{6}[-\s]?\d{2}[-\s]?\d{4})\b/g,
+  regex: /\b(\d{6}[\-\s]?\d{2}[\-\s]?\d{4})\b/g,
   placeholder: '[MY_IC_{n}]',
   priority: 90,
   severity: 'high',
   description: 'Malaysia MyKad/IC number (12 digits)',
   validator: (value: string, context: string) => {
-    const cleaned = value.replace(/[-\s]/g, '');
+    const cleaned = value.replace(/[\-\s]/g, '');
     if (cleaned.length !== 12) return false;
 
     // Context validation required
@@ -116,13 +116,13 @@ export const MALAYSIA_MYKAD: PIIPattern = {
  */
 export const PHILIPPINES_UMID: PIIPattern = {
   type: 'PHILIPPINES_UMID',
-  regex: /\b(\d{4}[-\s]?\d{7}[-\s]?\d)\b/g,
+  regex: /\b(\d{4}[\-\s]?\d{7}[\-\s]?\d)\b/g,
   placeholder: '[PH_UMID_{n}]',
   priority: 85,
   severity: 'high',
   description: 'Philippines UMID number (12 digits)',
   validator: (value: string, context: string) => {
-    const cleaned = value.replace(/[-\s]/g, '');
+    const cleaned = value.replace(/[\-\s]/g, '');
     if (cleaned.length !== 12) return false;
 
     // Context validation required


### PR DESCRIPTION
## Summary
This PR fixes a critical regex initialization error occurring in WebKit-based browsers (specifically Mobile Safari).

  In certain JavaScript engines, unescaped hyphens in character classes—when positioned between specific characters (e.g., [-\s] or [.-])—are interpreted as attempted ranges rather than literal hyphens. If the
  Unicode point of the first character is higher than the second, the engine throws an Invalid regular expression: range out of order exception, causing the library to fail during initialization.

 ## Changes
   - Hardened regex patterns across the packages/core pattern library.
   - Escaped literal hyphens in character classes where they could be misinterpreted as ranges (e.g., [\-\s] instead of [-\s]).
   - Standardized character class formatting for the [\s\u00A0.\-] pattern used in several validators.

## Impact
   - Fixes: Initialization crashes on iOS/iPadOS Safari.
   - Resilience: Improves cross-engine compatibility (Node.js, V8, and WebKit).
   - Behavior: No changes to the actual matching logic; this is a syntax-hardening update only.

## Testing performed
   - Verified regex validity in Node.js environment.
   - Manually verified problematic patterns against WebKit's regex engine.
   - Ran existing test suite via npm test to ensure no regressions in PII detection accuracy.

## Testing

- [x] `npm test`
- [x] `npm run lint`
- [x] Other (describe):

## Checklist

- [x] Added/updated tests
- [x] Updated documentation
- [x] Checked for breaking changes and documented migration steps if needed
- [x] Linked any relevant issues
