### PR TITLE
chore: setup biome linter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,38 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"ignoreUnknown": true
+	},
+	"formatter": {
+		"useEditorconfig": true
+	},
+	"linter": {
+		"enabled": true,
+    "domains": {
+      "types": "recommended",
+      "test": "recommended",
+      "react": "recommended"
+    },
+		"rules": {
+			"preset": "recommended"
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "glob": "^13.0.6",
     "tsx": "^4.22.4",
+    "@biomejs/biome": "2.5.1",
     "turbo": "^2.10.0",
     "typescript": "^5.8.3"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,8 @@
     "test:coverage": "vitest run --coverage",
     "bench": "vitest bench --run",
     "bench:watch": "vitest bench",
-    "lint": "tsc --noEmit",
+    "lint": "biome check . --diagnostic-level=error",
+    "typecheck": "tsc --noEmit --incremental",
     "clean": "rm -rf dist"
   },
   "license": "MIT",

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,9 @@
     "lint": {
       "outputs": []
     },
+    "typecheck": {
+      "outputs": ["*.tsbuildinfo"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
Part 2/4 of the mass-format stack.

- Add .editorconfig and biome.jsonc configuration
- Replace tsc lint with biome check in all packages
- Add typecheck script (tsc --noEmit) to all packages
- Add typecheck task to turbo.json