### PR TITLE
ci: npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Publish
 
 on:
   push:
@@ -9,11 +9,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Create Release Pull Request
+  publish:
+    name: Publish to npm
     runs-on: ubuntu-latest
+    environment: npm-publish
+    if: contains(github.event.head_commit.message, 'chore: version packages')
     permissions:
       contents: write
+      id-token: write
       pull-requests: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -22,12 +25,13 @@ jobs:
 
       - uses: ./.github/actions/setup-bun
 
-      - name: Create Release Pull Request
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Publish to npm
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          version: bun run version-packages
-          commit: "chore: version packages"
-          title: "chore: version packages"
+          publish: bun run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Splits the release workflow into two: one for version PRs, one for OIDC-authenticated npm publishing with an environment approval gate.

- **`release.yml`** — version PR creation only (no publish, no `NPM_TOKEN`, no `id-token: write`)
- **`publish.yml`** — new OIDC publish workflow:
  - `environment: npm-publish` — requires manual approval before publishing
  - `id-token: write` — enables GitHub OIDC token exchange with npm
  - `npm install -g npm@latest` — Node 22 ships npm 10.x; OIDC requires >= 11.5.1
  - Only triggers on commits containing `chore: version packages` (i.e., when the version PR is merged)
  - No `NPM_TOKEN` — npm CLI auto-detects the OIDC environment

`changesets/action@v1.9.0` already handles this cleanly (PR #545 skips writing `NPM_TOKEN` to `.npmrc` when undefined).

## Manual setup required after merge

See the comment below for detailed steps.