### PR TITLE
chore: version packages

### DIFF
--- a/.changeset/free-garlics-join.md
+++ b/.changeset/free-garlics-join.md
@@ -1,6 +1,0 @@
----
-"@openredaction/elysia": major
-"@openredaction/hono": major
----
-
-initial versions of the hono and elysia plugins for openredaction

--- a/packages/elysia/CHANGELOG.md
+++ b/packages/elysia/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openredaction/elysia
+
+## 1.0.0
+
+### Major Changes
+
+- [#64](https://github.com/sam247/openredaction/pull/64) [`a774341`](https://github.com/sam247/openredaction/commit/a774341fd6c17522eeac25d785d9c75beeb50656) Thanks [@atomicpages](https://github.com/atomicpages)! - initial versions of the hono and elysia plugins for openredaction

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openredaction/elysia",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "homepage": "https://openredaction.com",
   "bugs": {
     "url": "https://github.com/sam247/openredaction/issues"

--- a/packages/hono/CHANGELOG.md
+++ b/packages/hono/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openredaction/hono
+
+## 1.0.0
+
+### Major Changes
+
+- [#64](https://github.com/sam247/openredaction/pull/64) [`a774341`](https://github.com/sam247/openredaction/commit/a774341fd6c17522eeac25d785d9c75beeb50656) Thanks [@atomicpages](https://github.com/atomicpages)! - initial versions of the hono and elysia plugins for openredaction

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openredaction/hono",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "homepage": "https://openredaction.com",
   "bugs": {
     "url": "https://github.com/sam247/openredaction/issues"


### PR DESCRIPTION
## Version Packages

This PR was generated by Changesets to release Hono and Elysia integrations.

### Packages bumped

| Package | Current on npm | Proposed version |
|---|---|---|
| `@openredaction/hono` | not published | **1.0.0** |
| `@openredaction/elysia` | not published | **1.0.0** |

### Packages unchanged in this PR (but see publish note below)

| Package | Repo version | On npm |
|---|---|---|
| `@openredaction/core` | 1.1.2 | not published |
| `@openredaction/cli` | 1.1.2 | not published |
| `@openredaction/server` | 1.1.2 | not published |
| `@openredaction/express` | 1.1.2 | not published |
| `@openredaction/react` | 1.1.2 | not published |
| `openredaction` | 1.1.2 | 1.1.2 (skip) |

### Important: first publish scope

Merging this PR triggers `publish.yml` (after `npm-publish` environment approval). `changeset publish` will also attempt **first-time publishes** for the scoped monorepo packages that are not yet on npm at **1.1.2**, in addition to Hono/Elysia at **1.0.0**.

Please confirm Trusted Publishing is configured on npm and approve the `npm-publish` environment deployment before publishing.