### PR TITLE
fix(ci): reliably trigger OIDC publish after Version Packages merges

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
     "@changesets/changelog-github",
     { "repo": "sam247/openredaction" }
   ],
-  "commit": true,
+  "commit": ["@changesets/cli/commit", { "skipCI": false }],
   "fixed": [
     [
       "@openredaction/core",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,20 +3,110 @@ name: Publish
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Why run a manual OIDC publish? (for audit trail)
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  # Lightweight gate: do not use the npm-publish environment here, so routine
+  # main pushes never request an approval. Publish only when a Version Packages
+  # merge actually bumped packages/*/package.json, or on manual dispatch.
+  decide:
+    name: Detect publishable version bumps
+    runs-on: ubuntu-latest
+    outputs:
+      publish: ${{ steps.check.outputs.publish }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether to publish
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+          DISPATCH_REASON: ${{ github.event.inputs.reason }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual dispatch — will publish after npm-publish approval."
+            echo "Reason: ${DISPATCH_REASON}"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -z "${BEFORE:-}" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "No meaningful before SHA — skipping publish."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          publish=false
+
+          while IFS= read -r file; do
+            case "$file" in
+              packages/*/package.json)
+                old_version="$(
+                  git show "$BEFORE:$file" 2>/dev/null | node -e '
+                    let d = "";
+                    process.stdin.on("data", (c) => { d += c; });
+                    process.stdin.on("end", () => {
+                      try {
+                        process.stdout.write(JSON.parse(d).version || "");
+                      } catch {
+                        process.stdout.write("");
+                      }
+                    });
+                  ' || true
+                )"
+                new_version="$(
+                  git show "$AFTER:$file" | node -e '
+                    let d = "";
+                    process.stdin.on("data", (c) => { d += c; });
+                    process.stdin.on("end", () => {
+                      try {
+                        process.stdout.write(JSON.parse(d).version || "");
+                      } catch {
+                        process.stdout.write("");
+                      }
+                    });
+                  '
+                )"
+
+                if [ -n "$new_version" ] && [ "$old_version" != "$new_version" ]; then
+                  echo "Version bump detected: $file ${old_version:-<new>} -> $new_version"
+                  publish=true
+                fi
+                ;;
+            esac
+          done < <(git diff --name-only "$BEFORE" "$AFTER")
+
+          if [ "$publish" = true ]; then
+            echo "Publishable version bumps found."
+          else
+            echo "No packages/*/package.json version bumps in this push — skipping publish."
+          fi
+
+          echo "publish=${publish}" >> "$GITHUB_OUTPUT"
+
   publish:
     name: Publish to npm
+    needs: decide
+    if: needs.decide.outputs.publish == 'true'
     runs-on: ubuntu-latest
     environment: npm-publish
-    # Match direct version commits and merge commits that bring them onto main.
-    if: |
-      contains(github.event.head_commit.message, 'chore: version packages') ||
-      contains(toJSON(github.event.commits), 'chore: version packages')
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,6 +23,9 @@ jobs:
 
       - uses: ./.github/actions/setup-bun
 
+      # Version commits are created by Changesets with skipCI disabled in
+      # .changeset/config.json so merging the Version Packages PR can run CI
+      # and trigger publish.yml (which keys off packages/*/package.json bumps).
       - name: Create Release Pull Request
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0


### PR DESCRIPTION
## Summary

- **Root cause of #77:** `.changeset/config.json` had `"commit": true`, which expands to `skipCI: "version"`. The Version Packages commit therefore contained `[skip ci]`. GitHub skipped **all** workflows on merge — including `publish.yml` — so nothing reached the `npm-publish` environment gate. Separately, `publish.yml` only matched `chore: version packages`, which that commit never contained (`RELEASING: …`).
- **Fix at source:** set `"commit": ["@changesets/cli/commit", { "skipCI": false }]` so version commits no longer suppress Actions.
- **Reliable publish gate:** replace commit-message matching with a lightweight `decide` job that detects `packages/*/package.json` version bumps (no environment approval on routine main pushes). The OIDC `publish` job still uses `environment: npm-publish`, `id-token: write`, and no `NPM_TOKEN`.
- **Manual path:** `workflow_dispatch` on Publish (required reason) and Release for controlled validation after npm bootstrap.

## Failure mode (PR #77) — precise

1. Release created `changeset-release/main` with commit `RELEASING: Releasing 2 package(s)` + `[skip ci]`.
2. PR #77 was merged onto `main` as that same commit (`f1b6d80`).
3. GitHub saw `[skip ci]` → **zero** workflow runs on 2026-07-16.
4. Even without `[skip ci]`, the old `if: contains(..., 'chore: version packages')` would have skipped the publish job.

## Test plan

- [ ] Confirm this PR’s CI is green
- [ ] After merge, a normal (non-version) push to `main` runs Publish → `decide` → `publish=false` and does **not** request `npm-publish` approval
- [ ] After npm org + bootstrap + Trusted Publishers, use **Actions → Publish → Run workflow** with reason `post-bootstrap OIDC validation`, approve `npm-publish`, confirm packages publish via OIDC
- [ ] Later: add a changeset, merge, let Release open Version Packages PR, merge it, confirm Publish runs without relying on commit message text

## End-to-end validation (after npm owner bootstrap)

Do **not** run this until `@openredaction` org exists, all 7 scoped packages are on the registry, and Trusted Publisher is configured for all 8 packages (`publish.yml`, env `npm-publish`).

1. Merge this PR to `main`.
2. Complete npm owner steps from #98 (org → bootstrap publish with short-lived token → Trusted Publisher on each package).
3. **Controlled OIDC smoke test:**
   [Actions → Publish → Run workflow](https://github.com/sam247/openredaction/actions/workflows/publish.yml)
   - Reason: `post-bootstrap OIDC validation`
   - Approve the `npm-publish` environment deployment when prompted
   - Expect: npm CLI uses OIDC (no `NPM_TOKEN` in the job); unpublished versions publish; already-published versions are skipped by Changesets
4. **Automatic path smoke test:** add a tiny changeset → merge → Release opens/updates Version Packages PR → merge that PR → confirm Publish `decide` logs version bumps → approve `npm-publish` → publish succeeds.
5. Only after a successful OIDC publish: delete the `NPM_TOKEN` repo secret and (optionally) set npm package publishing access to disallow tokens.

Closes the pipeline half of #98 (npm Trusted Publisher / org / bootstrap remain owner-side).