### PR TITLE
chore: version packages

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @openredaction/cli
+
+## 1.1.3
+
+### Patch Changes
+
+- OIDC trusted-publishing smoke validation (patch-only).
+
+- Updated dependencies []:
+  - @openredaction/core@1.1.3

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openredaction/cli",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "homepage": "https://openredaction.com",
   "bugs": {
     "url": "https://github.com/sam247/openredaction/issues"

--- a/packages/compat/CHANGELOG.md
+++ b/packages/compat/CHANGELOG.md
@@ -1,0 +1,13 @@
+# openredaction
+
+## 1.1.3
+
+### Patch Changes
+
+- OIDC trusted-publishing smoke validation (patch-only).
+
+- Updated dependencies []:
+  - @openredaction/core@1.1.3
+  - @openredaction/react@1.1.3
+  - @openredaction/server@1.1.3
+  - @openredaction/express@1.1.3

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openredaction",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "homepage": "https://openredaction.com",
   "bugs": {
     "url": "https://github.com/sam247/openredaction/issues"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @openredaction/core
+
+## 1.1.3
+
+### Patch Changes
+
+- OIDC trusted-publishing smoke validation (patch-only).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openredaction/core",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "homepage": "https://openredaction.com",
   "bugs": {
     "url": "https://github.com/sam247/openredaction/issues"

--- a/packages/elysia/CHANGELOG.md
+++ b/packages/elysia/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openredaction/elysia
 
+## 1.0.1
+
+### Patch Changes
+
+- OIDC trusted-publishing smoke validation (patch-only).
+
+- Updated dependencies []:
+  - @openredaction/core@1.1.3
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openredaction/elysia",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://openredaction.com",
   "bugs": {
     "url": "https://github.com/sam247/openredaction/issues"

--- a/packages/express/CHANGELOG.md
+++ b/packages/express/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @openredaction/express
+
+## 1.1.3
+
+### Patch Changes
+
+- OIDC trusted-publishing smoke validation (patch-only).
+
+- Updated dependencies []:
+  - @openredaction/core@1.1.3

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openredaction/express",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "homepage": "https://openredaction.com",
   "bugs": {
     "url": "https://github.com/sam247/openredaction/issues"

--- a/packages/hono/CHANGELOG.md
+++ b/packages/hono/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openredaction/hono
 
+## 1.0.1
+
+### Patch Changes
+
+- OIDC trusted-publishing smoke validation (patch-only).
+
+- Updated dependencies []:
+  - @openredaction/core@1.1.3
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openredaction/hono",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://openredaction.com",
   "bugs": {
     "url": "https://github.com/sam247/openredaction/issues"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @openredaction/react
+
+## 1.1.3
+
+### Patch Changes
+
+- OIDC trusted-publishing smoke validation (patch-only).
+
+- Updated dependencies []:
+  - @openredaction/core@1.1.3

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openredaction/react",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "homepage": "https://openredaction.com",
   "bugs": {
     "url": "https://github.com/sam247/openredaction/issues"

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @openredaction/server
+
+## 1.1.3
+
+### Patch Changes
+
+- OIDC trusted-publishing smoke validation (patch-only).
+
+- Updated dependencies []:
+  - @openredaction/core@1.1.3

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openredaction/server",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "homepage": "https://openredaction.com",
   "bugs": {
     "url": "https://github.com/sam247/openredaction/issues"


### PR DESCRIPTION
## Summary

Single patch-only smoke release to validate OIDC trusted publishing end-to-end (after bootstrap + Trusted Publisher setup).

| Package | From | To |
|---|---|---|
| `@openredaction/core` / `cli` / `react` / `server` / `express` / `openredaction` | 1.1.2 | **1.1.3** |
| `@openredaction/hono` / `elysia` | 1.0.0 | **1.0.1** |

Changes limited to Changesets version metadata (`package.json` versions + changelogs). No product code.

## Test plan

- [ ] Merge this PR to `main`
- [ ] Confirm Publish workflow `decide` detects version bumps
- [ ] Approve `npm-publish` environment
- [ ] Confirm OIDC publish succeeds for the new patch versions
- [ ] Confirm provenance/attestations on at least one new version
- [ ] Delete legacy `NPM_TOKEN` secret only after the above


Made with [Cursor](https://cursor.com)