### PR TITLE
fix: stop shipping workspace:* in npm packages

### DIFF
--- a/.changeset/fix-workspace-protocol-leak.md
+++ b/.changeset/fix-workspace-protocol-leak.md
@@ -1,0 +1,12 @@
+---
+"openredaction": patch
+"@openredaction/core": patch
+"@openredaction/cli": patch
+"@openredaction/express": patch
+"@openredaction/react": patch
+"@openredaction/server": patch
+"@openredaction/hono": patch
+"@openredaction/elysia": patch
+---
+
+Fix published package manifests: rewrite `workspace:*` dependencies to concrete semver ranges before npm publish so consumers can install with npm, pnpm, and yarn.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -62,6 +62,8 @@ When your PR is merged to `main`, the **Release** workflow runs automatically. I
 
 Review the version bump and changelog entries, then merge the Version Packages PR. This triggers the Release workflow again — this time it publishes all 6 packages to npm and creates a git tag `v{version}`.
 
+**Bun note:** this repo uses Bun workspaces. Unlike pnpm, Bun/`changeset publish` does not rewrite `workspace:` protocol ranges into semver before packing. The `release` script therefore runs `scripts/resolve-workspace-protocol.mjs` (then `assert-no-workspace-protocol.mjs`) immediately before `changeset publish`. Do not commit the rewritten `package.json` files from a local dry-run.
+
 **Note:** npm never allows republishing the same version. If publish fails with "cannot publish over previously published versions", add a new changeset with a bump and go through the flow again.
 
 ## Install for users

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "prepare": "husky",
-    "release": "turbo run build --filter=./packages/* && changeset publish",
+    "release": "turbo run build --filter=./packages/* && bun run scripts/resolve-workspace-protocol.mjs && bun run scripts/assert-no-workspace-protocol.mjs && changeset publish",
+    "resolve-workspace-protocol": "bun run scripts/resolve-workspace-protocol.mjs",
+    "assert-no-workspace-protocol": "bun run scripts/assert-no-workspace-protocol.mjs",
     "test": "turbo run test",
     "typecheck": "turbo run typecheck",
     "version-packages": "changeset version"

--- a/scripts/assert-no-workspace-protocol.mjs
+++ b/scripts/assert-no-workspace-protocol.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env bun
+/**
+ * Fail the publish job if any packages/* package.json still contains a
+ * `workspace:` protocol in dependency fields. Prevents shipping unusable
+ * tarballs when Bun/Changesets skip protocol rewriting.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PACKAGES_DIR = join(import.meta.dir, "..", "packages");
+const DEP_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+];
+
+const offenders = [];
+
+for (const dir of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+  if (!dir.isDirectory()) {
+    continue;
+  }
+
+  const pkgPath = join(PACKAGES_DIR, dir.name, "package.json");
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  } catch {
+    continue;
+  }
+
+  for (const field of DEP_FIELDS) {
+    const deps = pkg[field];
+    if (!deps || typeof deps !== "object") {
+      continue;
+    }
+
+    for (const [name, range] of Object.entries(deps)) {
+      if (typeof range === "string" && range.startsWith("workspace:")) {
+        offenders.push(`${pkg.name} ${field}.${name}=${range}`);
+      }
+    }
+  }
+}
+
+if (offenders.length > 0) {
+  console.error(
+    "Refusing to publish: workspace: protocol still present in package.json:\n",
+  );
+  for (const line of offenders) {
+    console.error(`  - ${line}`);
+  }
+  console.error(
+    "\nRun `bun run scripts/resolve-workspace-protocol.mjs` before changeset publish.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  "OK: no workspace: protocol in packages/*/package.json dependency fields.",
+);

--- a/scripts/resolve-workspace-protocol.mjs
+++ b/scripts/resolve-workspace-protocol.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env bun
+/**
+ * Bun workspaces + `changeset publish` do not rewrite `workspace:` protocol
+ * into concrete semver ranges (unlike pnpm). Published tarballs then contain
+ * `workspace:*`, which breaks npm / pnpm / yarn consumers.
+ *
+ * @see https://github.com/oven-sh/bun/issues/24687
+ * @see https://github.com/changesets/changesets/issues/1468
+ *
+ * Run this immediately before `changeset publish` in CI. Mutates package.json
+ * files in place — safe on ephemeral CI runners; do not commit the result.
+ */
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+const PACKAGES_DIR = join(ROOT, "packages");
+
+const DEP_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+];
+
+function loadWorkspacePackages() {
+  /** @type {Map<string, { dir: string, pkg: Record<string, unknown> }>} */
+  const byName = new Map();
+
+  for (const dir of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+    if (!dir.isDirectory()) {
+      continue;
+    }
+
+    const pkgPath = join(PACKAGES_DIR, dir.name, "package.json");
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+      if (typeof pkg.name === "string" && typeof pkg.version === "string") {
+        byName.set(pkg.name, { dir: dir.name, pkg, pkgPath });
+      }
+    } catch {
+      // skip non-package dirs
+    }
+  }
+
+  return byName;
+}
+
+/**
+ * @param {string} range
+ * @param {string} version
+ */
+function resolveWorkspaceRange(range, version) {
+  if (range === "workspace:*" || range === "workspace:^") {
+    return `^${version}`;
+  }
+
+  if (range === "workspace:~") {
+    return `~${version}`;
+  }
+
+  if (range.startsWith("workspace:")) {
+    const rest = range.slice("workspace:".length);
+    if (rest === version || rest === `^${version}` || rest === `~${version}`) {
+      return rest.startsWith("^") || rest.startsWith("~")
+        ? rest
+        : `^${version}`;
+    }
+    // workspace:^1.2.3 or workspace:1.2.3 → strip protocol
+    return rest;
+  }
+
+  return null;
+}
+
+function main() {
+  const workspace = loadWorkspacePackages();
+  let replacements = 0;
+
+  for (const { pkg, pkgPath } of workspace.values()) {
+    let changed = false;
+
+    for (const field of DEP_FIELDS) {
+      const deps = pkg[field];
+      if (!deps || typeof deps !== "object") {
+        continue;
+      }
+
+      for (const [name, range] of Object.entries(deps)) {
+        if (typeof range !== "string" || !range.startsWith("workspace:")) {
+          continue;
+        }
+
+        const target = workspace.get(name);
+        if (!target) {
+          throw new Error(
+            `${pkg.name}: ${field}.${name} uses ${range} but ${name} is not in this workspace`,
+          );
+        }
+
+        const resolved = resolveWorkspaceRange(range, target.pkg.version);
+        if (!resolved) {
+          throw new Error(
+            `${pkg.name}: unsupported workspace range ${range} for ${name}`,
+          );
+        }
+
+        deps[name] = resolved;
+        changed = true;
+        replacements += 1;
+        console.log(`${pkg.name}: ${field}.${name}: ${range} -> ${resolved}`);
+      }
+    }
+
+    if (changed) {
+      writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+    }
+  }
+
+  console.log(
+    `Resolved ${replacements} workspace: dependenc${replacements === 1 ? "y" : "ies"}.`,
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary
- Resolve Bun `workspace:*` dependency ranges to concrete semver immediately before `changeset publish`, then assert none remain.
- Add a patch changeset so broken published packages (`openredaction` / scoped packages) can be re-released.
- Document the Bun + Changesets publish caveat in `docs/PUBLISHING.md`.

Fixes consumer installs failing with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND` / `EUNSUPPORTEDPROTOCOL` when installing `openredaction@1.1.3` (reported in #103).

## Test plan
- [x] Dry-run `resolve-workspace-protocol` + `assert-no-workspace-protocol` locally; packed `openredaction` tarball has no `workspace:` ranges
- [ ] Merge → Version Packages PR bumps to `1.1.4` / `1.0.2`
- [ ] After publish: clean `npm` / `pnpm` / `yarn` installs of `openredaction`
- [ ] `npm view <pkg> dependencies` for every affected package shows no `workspace:`
- [ ] Deprecate only the broken versions listed in #103 follow-up; leave `@openredaction/core@1.1.3` alone
- [ ] Comment on and close #103


Made with [Cursor](https://cursor.com)