### PR TITLE
ci: deprecate broken workspace:* npm releases

### DIFF
--- a/.github/workflows/deprecate-broken.yml
+++ b/.github/workflows/deprecate-broken.yml
@@ -1,0 +1,37 @@
+name: Deprecate broken releases
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  deprecate:
+    name: Deprecate workspace:* releases
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Deprecate broken versions
+        run: |
+          set -euo pipefail
+          MSG='Broken workspace:* dependencies in published package.json; use 1.1.4 or later (or 1.0.2 for @openredaction/hono and @openredaction/elysia).'
+
+          npm deprecate openredaction@1.1.3 "$MSG"
+          npm deprecate @openredaction/cli@1.1.3 "$MSG"
+          npm deprecate @openredaction/express@1.1.3 "$MSG"
+          npm deprecate @openredaction/react@1.1.3 "$MSG"
+          npm deprecate @openredaction/server@1.1.3 "$MSG"
+          npm deprecate @openredaction/hono@1.0.1 "$MSG"
+          npm deprecate @openredaction/elysia@1.0.1 "$MSG"
+
+          echo "Deprecated broken releases. Left @openredaction/core@1.1.3 alone."


### PR DESCRIPTION
## Summary
- One-shot `workflow_dispatch` to deprecate broken `workspace:*` releases after verifying `1.1.4` / `1.0.2`.
- Does **not** deprecate `@openredaction/core@1.1.3`.

## Test plan
- [ ] Merge and run `Deprecate broken releases`
- [ ] Approve `npm-publish`
- [ ] Confirm deprecated flags on npm
- [ ] Close #103