### PR TITLE
ci: fix OIDC auth for deprecate workflow

### DIFF
--- a/.github/workflows/deprecate-broken.yml
+++ b/.github/workflows/deprecate-broken.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          registry-url: https://registry.npmjs.org
+
       - name: Upgrade npm for OIDC trusted publishing
         run: npm install -g npm@latest
 


### PR DESCRIPTION
Wire `actions/setup-node` `registry-url` so npm OIDC auth is available for `npm deprecate` (previous run had no registry auth).