### PR TITLE
fix: harden release pipeline and repair CLI bin paths

### DIFF
--- a/.changeset/fix-cli-bins-npm-readme.md
+++ b/.changeset/fix-cli-bins-npm-readme.md
@@ -1,0 +1,6 @@
+---
+"@openredaction/cli": patch
+"openredaction": patch
+---
+
+Fix CLI bin paths to match emitted `.cjs` files so `npx openredaction` works after install. Refresh the `openredaction` npm README so the package page leads with a working first example instead of migration-only copy.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,29 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      # Guard: package.json main/module/types/exports/bin must exist after build.
+      # Catches silent packaging bugs (e.g. CLI bin pointing at .js while emit is .cjs).
+      - name: Assert package entrypoints exist
+        run: bun run assert-package-entrypoints
+
+  # Guard: pack tarballs and install into clean projects with npm/pnpm/yarn.
+  # Catches workspace: leaks, broken exports, and install-time failures that
+  # monorepo unit tests never see (class of bug in issue #103).
+  consumer-smoke:
+    name: Consumer smoke (pack + npm/pnpm/yarn)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup-bun
+        with:
+          node-version: "22"
+
+      - name: Enable Corepack package managers
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
+          corepack prepare yarn@1.22.22 --activate
+
+      - name: Consumer smoke
+        run: bun run consumer-smoke

--- a/MAINTAINER_RELEASE_CHECKLIST.md
+++ b/MAINTAINER_RELEASE_CHECKLIST.md
@@ -1,0 +1,82 @@
+# Maintainer release checklist
+
+Canonical process for shipping OpenRedaction packages to npm. Prefer this over
+ad-hoc memory. Details live in [`docs/PUBLISHING.md`](./docs/PUBLISHING.md).
+
+## Before you merge a feature PR
+
+- [ ] Changeset added (`bunx changeset`) for every user-facing package change
+- [ ] CI green on the PR — including **Build** (entrypoint assert) and
+      **Consumer smoke** (pack + npm/pnpm/yarn)
+- [ ] No `workspace:` ranges introduced outside workspace deps (they are OK in
+      repo sources; they must not ship)
+
+## Merge → version
+
+1. Merge the feature PR to `main`
+2. Wait for **Release** workflow to open/update **Version Packages**
+3. Review version bumps + changelogs
+4. Merge Version Packages
+
+Expected bumps (current fixed groups):
+
+- Group A: `openredaction`, `@openredaction/{core,cli,express,react,server}`
+- Group B: `@openredaction/{hono,elysia}`
+
+## Publish
+
+1. **Publish** workflow detects `packages/*/package.json` version bumps
+2. Approve the `npm-publish` environment when prompted
+3. Confirm the job runs `bun run release`, which is:
+   - `turbo build`
+   - `resolve-workspace-protocol` — Bun does not rewrite `workspace:` on publish
+   - `assert-no-workspace-protocol` — refuse to publish if rewrite missed anything
+   - `assert-package-entrypoints` — refuse if `main`/`exports`/`bin` files are missing
+   - `changeset publish`
+4. Confirm GitHub Releases / tags were created per package
+
+## Verification after publish
+
+Pre-publish install/exports/CJS/ESM/`tsc` coverage is already gated by CI
+(**Consumer smoke** + **Build** entrypoint assert). Do **not** re-run those
+manually unless CI was skipped or you suspect a registry-only failure.
+
+Registry-only checks CI cannot cover:
+
+```bash
+# Manifests on the registry (not the packed local tarball)
+npm view openredaction@latest dependencies
+npm view @openredaction/express@latest dependencies
+# Expect semver (^x.y.z), never workspace:*
+
+# CLI from the published tarball (bin paths only matter after publish)
+npx --yes @openredaction/cli@latest --help
+
+# Provenance attestation
+npm view openredaction@latest dist.attestations
+```
+
+If CI was green and the checks above pass, the release is verified.
+
+## Rollback / incident
+
+npm cannot unpublish recent public versions in most cases. Prefer:
+
+1. Ship a patch that fixes the defect
+2. `npm deprecate <pkg>@<broken>` with a clear message (needs owner token —
+   OIDC publish **cannot** deprecate; see [#108](https://github.com/sam247/openredaction/issues/108))
+3. Comment on the reporter issue with the fixed version
+
+## Issue handling
+
+- Packaging/install failures: treat as P0 until a patch is on `latest`
+- Open a follow-up for deprecations / docs drift that must not block the patch
+- Keep [#108](https://github.com/sam247/openredaction/issues/108) until broken
+  `1.1.3` / `1.0.1` versions are deprecated
+
+## Do not
+
+- Commit rewritten `package.json` files after a local `resolve-workspace-protocol` dry-run
+- Republish the same version
+- Treat “unit tests passed” as a substitute for consumer-smoke / entrypoint asserts
+- Deprecate `@openredaction/core@1.1.3` (that version was fine)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OpenRedaction
 
-[![Version](https://img.shields.io/badge/version-1.1.2-brightgreen.svg)](https://www.npmjs.com/package/openredaction)
+[![npm](https://img.shields.io/npm/v/openredaction.svg)](https://www.npmjs.com/package/openredaction)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Tests](https://img.shields.io/badge/tests-471%20passing-brightgreen.svg)](https://github.com/sam247/openredaction)
+[![CI](https://github.com/sam247/openredaction/actions/workflows/ci.yml/badge.svg)](https://github.com/sam247/openredaction/actions/workflows/ci.yml)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)
 
 OpenRedaction is an open-source JavaScript/TypeScript library for detecting and

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -62,9 +62,19 @@ When your PR is merged to `main`, the **Release** workflow runs automatically. I
 
 Review the version bump and changelog entries, then merge the Version Packages PR. This triggers the Release workflow again — this time it publishes all 6 packages to npm and creates a git tag `v{version}`.
 
-**Bun note:** this repo uses Bun workspaces. Unlike pnpm, Bun/`changeset publish` does not rewrite `workspace:` protocol ranges into semver before packing. The `release` script therefore runs `scripts/resolve-workspace-protocol.mjs` (then `assert-no-workspace-protocol.mjs`) immediately before `changeset publish`. Do not commit the rewritten `package.json` files from a local dry-run.
+**Bun note:** this repo uses Bun workspaces. Unlike pnpm, Bun/`changeset publish` does not rewrite `workspace:` protocol ranges into semver before packing. The `release` script therefore runs three guards immediately before `changeset publish`:
+
+1. `resolve-workspace-protocol.mjs` — rewrite `workspace:*` → `^version`
+2. `assert-no-workspace-protocol.mjs` — refuse publish if any `workspace:` remain (issue #103 class)
+3. `assert-package-entrypoints.mjs` — refuse publish if `main`/`exports`/`bin` paths are missing (CLI bin class)
+
+Do not commit the rewritten `package.json` files from a local dry-run.
+
+Maintainer checklist: [`MAINTAINER_RELEASE_CHECKLIST.md`](../MAINTAINER_RELEASE_CHECKLIST.md).
 
 **Note:** npm never allows republishing the same version. If publish fails with "cannot publish over previously published versions", add a new changeset with a bump and go through the flow again.
+
+**OIDC vs deprecate:** Trusted publishing can publish with provenance. It cannot run `npm deprecate`. Deprecations need an owner login or an Automation token (see [#108](https://github.com/sam247/openredaction/issues/108)).
 
 ## Install for users
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/sam247/redactit.git"
+    "url": "https://github.com/sam247/openredaction.git"
   },
   "license": "MIT",
   "workspaces": [
@@ -31,9 +31,11 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "prepare": "husky",
-    "release": "turbo run build --filter=./packages/* && bun run scripts/resolve-workspace-protocol.mjs && bun run scripts/assert-no-workspace-protocol.mjs && changeset publish",
+    "release": "turbo run build --filter=./packages/* && bun run scripts/resolve-workspace-protocol.mjs && bun run scripts/assert-no-workspace-protocol.mjs && bun run scripts/assert-package-entrypoints.mjs && changeset publish",
     "resolve-workspace-protocol": "bun run scripts/resolve-workspace-protocol.mjs",
     "assert-no-workspace-protocol": "bun run scripts/assert-no-workspace-protocol.mjs",
+    "assert-package-entrypoints": "bun run scripts/assert-package-entrypoints.mjs",
+    "consumer-smoke": "bash scripts/consumer-smoke.sh",
     "test": "turbo run test",
     "typecheck": "turbo run typecheck",
     "version-packages": "changeset version"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,8 +27,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "bin": {
-    "openredaction": "./dist/index.cli.js",
-    "openredaction-test-pattern": "./dist/test-pattern.js"
+    "openredaction": "./dist/index.cli.cjs",
+    "openredaction-test-pattern": "./dist/test-pattern.cjs"
   },
   "files": [
     "dist"

--- a/packages/compat/README.md
+++ b/packages/compat/README.md
@@ -1,20 +1,28 @@
 # openredaction
 
-Backward-compatibility package that re-exports `@openredaction/core`,
-`@openredaction/express`, `@openredaction/react`, and `@openredaction/server`
-under the original `openredaction` import path. Use this if you're migrating
-from the monolithic package — new projects should install scoped packages
-directly.
-
-## Installation
+Production-ready PII detection and redaction for JavaScript/TypeScript.
+Detects emails, phones, names, and 570+ other patterns locally — regex-first,
+privacy-first, MIT licensed.
 
 ```bash
 npm install openredaction
 ```
 
-## Usage
+```ts
+import { OpenRedaction } from "openredaction";
 
-Everything works as before:
+const redactor = new OpenRedaction({ redactionMode: "placeholder" });
+const { redacted } = await redactor.detect(
+  "Contact Jane at jane@example.com",
+);
+// "Contact [NAME_XXXX] at [EMAIL_XXXX]"
+```
+
+This unscoped package re-exports `@openredaction/core` plus Express/React/server
+integrations under the original `openredaction` import path. New projects that
+only need detection can install `@openredaction/core` instead.
+
+## Subpath imports
 
 ```ts
 import { OpenRedaction, openredactionMiddleware } from "openredaction";
@@ -22,16 +30,19 @@ import { usePIIDetector } from "openredaction/react";
 import { createAPIServer } from "openredaction/server";
 ```
 
-## Migration to Scoped Packages
+## Migration to scoped packages
 
 | Old import             | New package                                      |
 | ---------------------- | ------------------------------------------------ |
-| `openredaction`        | `@openredaction/core` + `@openredaction/express` |
+| `openredaction`        | `@openredaction/core` (+ `@openredaction/express` if needed) |
 | `openredaction/react`  | `@openredaction/react`                           |
 | `openredaction/server` | `@openredaction/server`                          |
 
 Optional peer deps (`react`, `pdf-parse`, `mammoth`, `tesseract.js`) only apply
 when you use those integrations.
+
+Docs: [openredaction.com](https://openredaction.com) ·
+[Playground](https://openredaction.com/playground)
 
 ## License
 

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -96,5 +96,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "description": "Production-ready PII detection and redaction for JavaScript/TypeScript. Regex-first, local-by-default, 570+ patterns."
 }

--- a/scripts/assert-package-entrypoints.mjs
+++ b/scripts/assert-package-entrypoints.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env bun
+/**
+ * Release guard: after `turbo build`, every path declared in a public
+ * package.json (`main`, `module`, `types`, `exports`, `bin`) must exist on disk.
+ *
+ * Why: unit tests never exercise the published file layout. A bundler rename
+ * (e.g. emitting `index.cli.cjs` while `bin` still points at `index.cli.js`)
+ * ships a tarball that installs cleanly but fails at runtime — as happened
+ * with `@openredaction/cli@1.1.4`.
+ *
+ * Wired into CI (build job) and `bun run release` so broken manifests cannot
+ * reach npm.
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PACKAGES_DIR = join(import.meta.dir, "..", "packages");
+
+/** @param {unknown} value @param {string[]} out */
+function collectPaths(value, out) {
+  if (typeof value === "string" && value.startsWith(".")) {
+    out.push(value);
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    for (const child of Object.values(value)) {
+      collectPaths(child, out);
+    }
+  }
+}
+
+function main() {
+  /** @type {string[]} */
+  const errors = [];
+
+  for (const dir of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+    if (!dir.isDirectory()) {
+      continue;
+    }
+
+    const pkgDir = join(PACKAGES_DIR, dir.name);
+    const pkgPath = join(pkgDir, "package.json");
+    if (!existsSync(pkgPath)) {
+      continue;
+    }
+
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+    if (pkg.private) {
+      continue;
+    }
+
+    /** @type {string[]} */
+    const paths = [];
+    for (const field of ["main", "module", "types"]) {
+      if (typeof pkg[field] === "string") {
+        paths.push(pkg[field]);
+      }
+    }
+    collectPaths(pkg.exports, paths);
+    collectPaths(pkg.bin, paths);
+
+    const unique = [...new Set(paths)];
+    for (const rel of unique) {
+      const abs = join(pkgDir, rel);
+      if (!existsSync(abs)) {
+        errors.push(`${pkg.name}: missing ${rel}`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error("Package entrypoint assert failed:\n");
+    for (const line of errors) {
+      console.error(`  - ${line}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("OK: all published package entrypoints exist on disk.");
+}
+
+main();

--- a/scripts/consumer-smoke.sh
+++ b/scripts/consumer-smoke.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Release guard: pack local packages into clean temp projects and verify that
+# a first-time consumer can install and use openredaction.
+#
+# Why: monorepo CI can pass while published tarballs are unusable
+# (workspace: leaks, broken exports, missing types, CJS/ESM mismatches).
+# This script is the automated form of "mkdir /tmp/app && npm/pnpm/yarn add …".
+#
+# Checks per package manager (npm, pnpm, yarn):
+#   - install from packed .tgz succeeds
+#   - CJS require + ESM import work
+#   - minimal detect() produces a redaction
+#   - TypeScript compiles a tiny consumer
+#
+# Mutates packages/*/package.json via resolve-workspace-protocol; restores
+# them from a backup taken at start (preserves uncommitted local edits).
+# Wired into CI as the "Consumer smoke" job.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+NODE_MAJOR="$(node -p "process.versions.node.split('.')[0]")"
+if [ "$NODE_MAJOR" -lt 20 ]; then
+  echo "consumer-smoke requires Node >= 20 (got $(node -v))" >&2
+  exit 1
+fi
+
+PKG_BACKUP="$(mktemp -d)"
+for dir in "$ROOT"/packages/*/; do
+  base="$(basename "$dir")"
+  cp "$dir/package.json" "$PKG_BACKUP/$base.json"
+done
+
+cleanup() {
+  for dir in "$ROOT"/packages/*/; do
+    base="$(basename "$dir")"
+    if [ -f "$PKG_BACKUP/$base.json" ]; then
+      cp "$PKG_BACKUP/$base.json" "$dir/package.json"
+    fi
+  done
+  rm -rf "$PKG_BACKUP"
+}
+trap cleanup EXIT
+
+echo "==> build packages"
+bunx turbo run build --filter=./packages/*
+
+echo "==> resolve workspace: protocol for packing"
+bun run scripts/resolve-workspace-protocol.mjs
+bun run scripts/assert-no-workspace-protocol.mjs
+bun run scripts/assert-package-entrypoints.mjs
+
+STAGING="$(mktemp -d)"
+SMOKE_ROOT="$(mktemp -d)"
+echo "staging=$STAGING"
+echo "smoke=$SMOKE_ROOT"
+
+echo "==> pack"
+(
+  cd "$STAGING"
+  for dir in core express react server cli hono elysia compat; do
+    npm pack "$ROOT/packages/$dir" --silent
+  done
+)
+
+install_from_packs() {
+  local mgr="$1"
+  local dir="$SMOKE_ROOT/$mgr"
+  mkdir -p "$dir"
+  cd "$dir"
+  npm init -y >/dev/null 2>&1
+
+  case "$mgr" in
+    npm)
+      npm install \
+        "$STAGING"/openredaction-core-*.tgz \
+        "$STAGING"/openredaction-express-*.tgz \
+        "$STAGING"/openredaction-react-*.tgz \
+        "$STAGING"/openredaction-server-*.tgz \
+        "$STAGING"/openredaction-1.*.tgz
+      ;;
+    pnpm)
+      pnpm add \
+        "$STAGING"/openredaction-core-*.tgz \
+        "$STAGING"/openredaction-express-*.tgz \
+        "$STAGING"/openredaction-react-*.tgz \
+        "$STAGING"/openredaction-server-*.tgz \
+        "$STAGING"/openredaction-1.*.tgz
+      ;;
+    yarn)
+      yarn add \
+        "$STAGING"/openredaction-core-*.tgz \
+        "$STAGING"/openredaction-express-*.tgz \
+        "$STAGING"/openredaction-react-*.tgz \
+        "$STAGING"/openredaction-server-*.tgz \
+        "$STAGING"/openredaction-1.*.tgz
+      ;;
+    *)
+      echo "unknown manager: $mgr" >&2
+      exit 1
+      ;;
+  esac
+}
+
+write_fixtures() {
+  cat > cjs-detect.cjs <<'EOF'
+const { OpenRedaction } = require("openredaction");
+
+(async () => {
+  const redactor = new OpenRedaction();
+  // Avoid example.com — filtered as a common false-positive domain.
+  const { redacted, detections } = await redactor.detect(
+    "email me at smoke@gmail.com",
+  );
+  const text = String(redacted);
+  const ok =
+    text.includes("[EMAIL") ||
+    text.includes("***") ||
+    (Array.isArray(detections) && detections.length > 0);
+  if (!ok) {
+    console.error("CJS detect produced no redaction/detections", {
+      redacted,
+      detections,
+    });
+    process.exit(1);
+  }
+  console.log("CJS detect ok");
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+EOF
+
+  cat > esm-detect.mjs <<'EOF'
+import { OpenRedaction } from "openredaction";
+
+const redactor = new OpenRedaction();
+const { redacted, detections } = await redactor.detect(
+  "email me at smoke@gmail.com",
+);
+const text = String(redacted);
+const ok =
+  text.includes("[EMAIL") ||
+  text.includes("***") ||
+  (Array.isArray(detections) && detections.length > 0);
+if (!ok) {
+  console.error("ESM detect produced no redaction/detections", {
+    redacted,
+    detections,
+  });
+  process.exit(1);
+}
+console.log("ESM detect ok");
+EOF
+
+  cat > index.ts <<'EOF'
+import { OpenRedaction } from "openredaction";
+
+async function main() {
+  const redactor = new OpenRedaction();
+  const { redacted } = await redactor.detect("email me at smoke@gmail.com");
+  console.log(redacted);
+}
+
+void main();
+EOF
+
+  cat > tsconfig.json <<'EOF'
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["index.ts"]
+}
+EOF
+}
+
+run_checks() {
+  write_fixtures
+  node cjs-detect.cjs
+  node esm-detect.mjs
+  # Avoid mutating the consumer lockfile across managers; fetch tsc ephemerally.
+  npx --yes -p typescript tsc -p .
+  node dist/index.js >/dev/null
+  echo "tsc ok"
+}
+
+for mgr in npm pnpm yarn; do
+  if ! command -v "$mgr" >/dev/null 2>&1; then
+    echo "skip $mgr (not installed)"
+    continue
+  fi
+  echo "==> smoke with $mgr"
+  install_from_packs "$mgr"
+  cd "$SMOKE_ROOT/$mgr"
+  run_checks
+done
+
+echo "OK: consumer smoke passed"


### PR DESCRIPTION
## Summary

Final v1.x release-hardening milestone. Every change maps to a real class of packaging failure we have already hit or nearly shipped.

### Bug fixes
- Fix `@openredaction/cli` `bin` paths (`.js` → `.cjs`) so they match tsdown output — `npx openredaction` is broken on `1.1.4` today because the tarball only contains `.cjs` files
- Refresh `openredaction` npm `description` + README so the registry page leads with a working first example instead of migration-only “compat shim” copy

### Release hardening
- `assert-package-entrypoints`: after build / before publish, every `main`/`module`/`types`/`exports`/`bin` path must exist on disk (CLI bin class of bug)
- `consumer-smoke`: pack local tarballs, install into clean projects with npm/pnpm/yarn, run CJS + ESM `detect()` + `tsc` (workspace-protocol / install class of bug from #103)
- Wire both into `bun run release` alongside existing workspace-protocol resolve/assert

### Documentation
- Add `MAINTAINER_RELEASE_CHECKLIST.md` as the canonical release process; post-publish verification is registry-only (CI already covers pack/install/runtime)
- Update `docs/PUBLISHING.md` to document the three pre-publish guards and OIDC vs `npm deprecate` (#108)
- Fix root README npm version badge (was hardcoded `1.1.2`) and root `package.json` `repository` URL (`redactit.git` → `openredaction.git`)

### CI
- Build job: run entrypoint assert after `turbo build`
- New **Consumer smoke** job: Corepack npm/pnpm/yarn + `bun run consumer-smoke`

## Why each guard exists
| Guard | Failure class it blocks |
|-------|-------------------------|
| `assert-package-entrypoints` | Declared entry files missing from dist (CLI `@1.1.4`) |
| `consumer-smoke` | Tarball installs/runtime break while monorepo tests pass (`workspace:` #103) |
| release script wiring | Publish cannot skip the above |

## Test plan
- [ ] CI green on this PR (lint, tests, build + entrypoint assert, consumer smoke)
- [ ] After merge + Version Packages + publish: `npx --yes @openredaction/cli@latest --help` works
- [ ] `npm view openredaction@latest dependencies` has no `workspace:`
- [ ] Complete [#108](https://github.com/sam247/openredaction/issues/108) deprecations with owner credentials (out of band)


Made with [Cursor](https://cursor.com)