### PR TITLE
Promote PII Redaction to root guide and retire blog post

### DIFF
--- a/site/app/blog/[slug]/page.tsx
+++ b/site/app/blog/[slug]/page.tsx
@@ -322,6 +322,57 @@ export default async function BlogPost(props: {
     url: pageUrl,
   };
 
+  // Question-form GSC queries for this URL had impressions with near-zero CTR;
+  // FAQ rich results improve snippet eligibility without changing page intent.
+  const supportFaqSchema =
+    params.slug === "pii-in-support-tickets"
+      ? {
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: [
+            {
+              "@type": "Question",
+              name: "How do you handle PII in customer support tickets?",
+              acceptedAnswer: {
+                "@type": "Answer",
+                text: "Assume every inbound channel will receive sensitive data. Collect the minimum needed to resolve the ticket, redact at ingest before indexing, mask identifiers in agent views, and keep short retention on unredacted transcripts.",
+              },
+            },
+            {
+              "@type": "Question",
+              name: "What PII commonly appears in support emails and chat?",
+              acceptedAnswer: {
+                "@type": "Answer",
+                text: "Support threads often include names, emails, phones, account references, government or financial IDs, passwords and OTPs pasted to debug, and sometimes health or regulated context in attachments and screenshots.",
+              },
+            },
+            {
+              "@type": "Question",
+              name: "How should agents respond when a customer pastes a card number or password?",
+              acceptedAnswer: {
+                "@type": "Answer",
+                text: "Redact immediately (for cards, keep only the last four digits if needed), remove the value from searchable ticket history, log a brief remediation note, and route the user to a secure upload or verification path instead of asking for secrets in free text.",
+              },
+            },
+          ],
+        }
+      : null;
+
+  const pageFaqSchema = supportFaqSchema;
+
+  // Process content - ensure links have proper styling
+  const processedContent = post.content
+    .replace(/<a href="([^"]+)">/g, (_match: string, href: string) => {
+      if (
+        href.startsWith("/") ||
+        href.startsWith("https://openredaction.com")
+      ) {
+        return `<a href="${href}" style="color: #fff; text-decoration: underline; hover:color: #d1d5db;">`;
+      }
+      return `<a href="${href}" target="_blank" rel="noopener noreferrer" style="color: #fff; text-decoration: underline;">`;
+    })
+    .trim();
+
   return (
     <div className="min-h-screen bg-black text-white">
       <Header />
@@ -333,6 +384,15 @@ export default async function BlogPost(props: {
           __html: JSON.stringify(blogPostingSchema),
         }}
       />
+      {pageFaqSchema ? (
+        <script
+          type="application/ld+json"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: FAQ JSON-LD from static answers grounded in page content
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(pageFaqSchema),
+          }}
+        />
+      ) : null}
       <main className="pt-[148px] pb-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <Link

--- a/site/app/blog/[slug]/page.tsx
+++ b/site/app/blog/[slug]/page.tsx
@@ -109,206 +109,11 @@ const blogPosts: { [key: string]: any } = {
       <div style="margin-top: 3rem; padding: 1.5rem; background-color: #111827; border: 1px solid #374151; border-radius: 0.5rem;">
         <h3 style="margin-top: 0; margin-bottom: 1rem; font-size: 1.25rem; font-weight: 600; color: #fff;">Related</h3>
         <ul style="margin-bottom: 0; padding-left: 1.5rem; list-style-type: disc; color: #d1d5db;">
-          <li style="margin-bottom: 0.5rem;"><a href="/pii-redaction" style="color: #fff; text-decoration: underline;">PII redaction for AI systems</a></li>
-          <li style="margin-bottom: 0.5rem;"><a href="/blog/pii-detection-for-ai" style="color: #fff; text-decoration: underline;">PII detection for AI workflows</a></li>
+          <li style="margin-bottom: 0.5rem;"><a href="/pii-redaction" style="color: #fff; text-decoration: underline;">PII redaction</a></li>
           <li style="margin-bottom: 0.5rem;"><a href="/blog/pii-in-support-tickets" style="color: #fff; text-decoration: underline;">PII in support tickets &amp; chat</a></li>
           <li style="margin-bottom: 0.5rem;"><a href="/open-source-ai-redaction-tools" style="color: #fff; text-decoration: underline;">Open source AI redaction tools</a></li>
           <li style="margin-bottom: 0.5rem;"><a href="/playground" style="color: #fff; text-decoration: underline;">Playground</a></li>
           <li style="margin-bottom: 0.5rem;"><a href="/docs" style="color: #fff; text-decoration: underline;">Documentation</a></li>
-        </ul>
-      </div>
-    `,
-  },
-  "pii-detection-for-ai": {
-    title:
-      "How to Detect and Redact PII in LLM Prompts Before They Reach the Model",
-    date: "2025-12-05",
-    category: "Guide",
-    authorName: "Sam Pettiford",
-    authorImage: "/author.jpg",
-    authorLinkedIn: "https://www.linkedin.com/in/sampettiford/",
-    authorBio:
-      "Founder of OpenRedaction, focused on privacy-safe LLM pipelines and production-grade data redaction patterns for modern teams.",
-    excerpt:
-      "Detect and redact PII in LLM inputs and outputs locally—before prompts hit vendors, logs, or RAG indexes. Pattern-first guardrails for AI pipelines.",
-    content: `
-      <p>Large Language Models (LLMs) are extraordinary at handling messy, unstructured text. They effortlessly parse incomplete sentences, analyze context, and synthesize fluent replies—but that same flexibility makes them eager to absorb anything passed their way: names, email addresses, national IDs, financial details, or confidential documents.</p>
-      <p>Without strict boundaries, your AI system can unintentionally become a privacy sink—logging sensitive content across model pipelines, traces, or fine-tuning datasets. The solution is not blind trust, it is visibility and repeatable redaction layers built directly into every boundary of your data flow.</p>
-      <p>This guide explores where Personally Identifiable Information (PII) hides within AI systems, how to conceptualize risk, and how OpenRedaction — plus <code>@openredaction/express</code> middleware — fits into secure workflows for prompts, retrieval systems, and observability logs.</p>
-
-      <h2>1. The AI Privacy Problem: Unstructured Risk Everywhere</h2>
-      <p>The AI development stack is inherently porous. Every message, document, or vector embedding can pass through multiple layers of software, from gateways and middlewares to third-party APIs. Each layer presents unique opportunities for accidental data exposure.</p>
-      <h3>Common Injection Points</h3>
-      <ul>
-        <li><strong>Inbound streams:</strong> User prompts, uploads, and pasted exports (CSV, DOCX, or CRM snapshots).</li>
-        <li><strong>Processing layers:</strong> System logs, traces, APM instrumentation, and replay tools used for debugging.</li>
-        <li><strong>Storage:</strong> Vector databases, custom embeddings, RAG indexes, and training sets retaining raw payloads.</li>
-        <li><strong>Outbound channels:</strong> Model-generated responses that echo user prompts, retrieved snippets, or internal context.</li>
-      </ul>
-      <p>One interaction can fan out through half a dozen network boundaries, cloud storage, caching layers, message queues, and analytics systems. Treat the first hop (typically the API gateway or Express.js middleware) as your critical control plane. That is where redaction must begin.</p>
-
-      <h2>2. What You Are Actually Protecting Against</h2>
-      <p>LLM privacy challenges are rarely about malicious intent, they stem from operational sprawl, where sensitive inputs get replicated or logged unintentionally.</p>
-      <ul>
-        <li><strong>Accidental logging:</strong> Prompts, completions, and file content copied into observability platforms (Datadog, LogStream, Elastic) that lack structured privacy controls.</li>
-        <li><strong>Vendor and residency risk:</strong> Text leaving your legal region or entering subprocessors operated by the model vendor.</li>
-        <li><strong>Retrieval leakage (RAG, fine-tuning):</strong> Unredacted chunks reappearing in unrelated completions due to embeddings storing human-identifiable metadata.</li>
-        <li><strong>Compliance complexity:</strong> Each duplicate makes GDPR deletion requests and DSARs exponentially harder.</li>
-      </ul>
-      <p>These risks scale faster than visibility. To manage them, engineers must design PII-aware pipelines, where every text transformation, ingestion step, and storage event is privacy-scoped.</p>
-
-      <h2>3. Pattern-First vs Machine Learning Detection</h2>
-      <p>There are two dominant paradigms for detecting sensitive text: pattern-first (regex-based) and ML/NLP-based. The best production systems combine both strategically.</p>
-      <h3>Pattern-First (Regex / Rule-Based)</h3>
-      <p>Regex-driven detectors catch structured identifiers, emails, phone numbers, credit card numbers, postal codes, and national IDs, with deterministic precision.</p>
-      <p><strong>Advantages:</strong></p>
-      <ul>
-        <li>Fast, local, and auditable.</li>
-        <li>Requires no external data processor.</li>
-        <li>Easy to embed into existing gateways or Express.js middleware.</li>
-      </ul>
-      <p>This approach forms step one in any privacy stack, your PII firewall before content ever reaches an LLM API.</p>
-      <p>Use <a href="/nodejs-redaction">@openredaction/express</a> middleware to scrub request bodies at the gateway:</p>
-      <pre><code>import { openredactionMiddleware } from '@openredaction/express';
-
-app.use(openredactionMiddleware({ autoRedact: true }));</code></pre>
-      <p>Combined with local <code>OpenRedaction.detect()</code> on prompt fields, every inbound payload can be scrubbed with deterministic regex before external transmission. Full walkthrough: <a href="/pii-redaction">PII redaction for AI systems</a>.</p>
-      <h3>ML / Named Entity Recognition (NER)</h3>
-      <p>NER-based models expand detection to unstructured text, names, organizations, and contextual references. They use statistical patterns and embeddings rather than explicit formulas.</p>
-      <p><strong>Advantages:</strong></p>
-      <ul>
-        <li>Powerful for conversational or narrative text.</li>
-        <li>Detects entities missed by rigid regex (e.g., "John from Barclays" or "Emma's discharge summary").</li>
-      </ul>
-      <p><strong>Trade-offs:</strong></p>
-      <ul>
-        <li>Slower and costlier.</li>
-        <li>Adds potential data residency issues, since some frameworks outsource inference.</li>
-        <li>Requires additional privacy safeguards if running externally.</li>
-      </ul>
-      <p><strong>Optimal architecture:</strong></p>
-      <ul>
-        <li>Run high-precision pattern redaction locally.</li>
-        <li>Optionally apply NER within a private VPC.</li>
-        <li>Merge spans and enforce single-pass redaction.</li>
-      </ul>
-      <p>OpenRedaction focuses on step 1 — the part you can deploy everywhere, safely, without external API calls. Optional local NER can sit behind the same boundary when you need free-text name coverage.</p>
-
-      <h2>4. Wiring Detection into Your Infrastructure</h2>
-      <p>Modern AI apps often integrate dozens of components, with data moving bidirectionally across LLM APIs, vector indices, and analytics dashboards. You need to wire PII detection across all data surfaces that cross a trust boundary.</p>
-      <h3>Core Locations for Redaction</h3>
-      <p><strong>LLM Gateway / Middleware:</strong><br />Redact request bodies before they leave your secure network.</p>
-      <pre><code>import { openredactionMiddleware } from '@openredaction/express';
-
-app.use(express.json());
-app.use(openredactionMiddleware({
-  autoRedact: true,
-  fields: ['prompt', 'message', 'content'],
-}));</code></pre>
-      <p>For model calls, wrap the OpenAI (or other LLM) client with <code>OpenRedaction.detect()</code> so only redacted text leaves your process. See <a href="/redact-pii-before-openai">Redact PII before OpenAI</a>.</p>
-      <p><strong>RAG Pipeline Ingestion:</strong><br />When processing documents for Retrieval-Augmented Generation, redact text early before embeddings and chunking. That way, your vector database never stores raw identifiers.</p>
-      <p><strong>Log and Trace Streams:</strong><br />Scrub payloads before they hit APM systems or cloud observability tools. Use stream filters that detect and mask sensitive tokens in the log formatter.</p>
-      <p><strong>Response Path (Echo Suppression):</strong><br />Scan generated replies before storage or display. Models can inadvertently echo user inputs; suppression filters prevent accidental resurfacing of PII.</p>
-      <p>This architecture is simple but powerful: every layer performs a privacy check just before data exits its internal domain.</p>
-
-      <h2>5. Redaction Style and Consistency</h2>
-      <p>Redaction strategy defines how PII is represented post-sanitization. Consistency beats cleverness, auditors prefer a stable, predictable approach.</p>
-      <h3>Placeholder vs Partial Masking</h3>
-      <ul>
-        <li>Full placeholders (e.g., {{EMAIL_REDACTED}}) are best for external model interactions.</li>
-        <li>Partial masking (e.g., jo***@domain.com) is suitable only for internal dashboards or controlled analytics.</li>
-      </ul>
-      <p>Document your chosen style, apply it globally across pipelines, and version-control redaction schemas as part of data governance metadata.</p>
-      <p>OpenRedaction supports multiple <code>redactionMode</code> values — <code>placeholder</code>, <code>mask-middle</code>, <code>mask-all</code>, <code>format-preserving</code>, and <code>token-replace</code> — so you can pick irreversible placeholders for vendors and softer masking for internal tools.</p>
-
-      <h2>6. Proving It Works: Verification and Audit</h2>
-      <p>Privacy assurance is not theoretical, it requires continuous, automated proof. Build regression pipelines that simulate realistic scenarios across your AI stack.</p>
-      <ul>
-        <li>Synthetic PII regression tests: Generate fake data, emails, IDs, card numbers, and feed it through your gateway to ensure redaction consistency.</li>
-        <li>Search audits: Periodically scan vector databases and log stores using regex patterns or hash-checks for synthetic markers.</li>
-        <li>Latency measurement: Maintain a defined threshold (e.g., less than 50ms per prompt redaction). If performance drops, teams may bypass redaction under pressure, a major security risk.</li>
-      </ul>
-      <h3>Example Audit Flow</h3>
-      <ul>
-        <li>Inject canary values (e.g., test-3456-email@piitest.co.uk) into prompts.</li>
-        <li>Verify they never appear in logs, embedding vectors, or LLM responses.</li>
-        <li>Generate compliance reports referencing test timestamps and sanitized outputs.</li>
-      </ul>
-      <p>This cycle creates active assurance, privacy that operates as part of CI/CD rather than afterthought compliance.</p>
-
-      <h2>7. Integrating with the OpenAI SDK</h2>
-      <p>There is no separate OpenAI vendor package required. Call OpenRedaction locally, then pass only redacted text to the official OpenAI client:</p>
-      <pre><code>import OpenAI from 'openai';
-import { OpenRedaction } from 'openredaction';
-
-const client = new OpenAI({ apiKey: process.env.OPENAI_KEY });
-const redactor = new OpenRedaction({
-  redactionMode: 'placeholder',
-  deterministic: true,
-});
-
-async function safeCompletion(prompt) {
-  const { redacted } = await redactor.detect(prompt);
-  return client.chat.completions.create({
-    model: 'gpt-4.1-mini',
-    messages: [{ role: 'user', content: redacted }],
-  });
-}</code></pre>
-      <p>This keeps sensitive data out of vendor traffic while preserving compliance expectations under GDPR, CCPA, and UK DPA 2018. Pair it with:</p>
-      <ul>
-        <li>Compliance presets (<code>gdpr</code>, <code>hipaa</code>, <code>pci-dss</code>, and others).</li>
-        <li>Detection metadata retained in your own logs — never the raw PII.</li>
-        <li><code>@openredaction/express</code> middleware for auto-scrubbing inbound JSON bodies.</li>
-      </ul>
-      <p>Together, gateway middleware and a local <code>detect()</code> wrapper form a privacy perimeter across data entry, model invocation, and retention.</p>
-
-      <h2>8. Deployment Patterns for Self-Hosted Privacy</h2>
-      <p>For enterprise compliance, you may choose to host redaction infrastructure locally rather than through a cloud processor.</p>
-      <h3>Recommended Setup</h3>
-      <ul>
-        <li>Self-hosted detector: run OpenRedaction and <code>@openredaction/express</code> inside a secure Kubernetes namespace (or any Node process you control).</li>
-        <li>Isolated ingress queue: All inbound requests are queued and sanitized before API forwarding.</li>
-        <li>Environment separation: Maintain distinct namespaces for preprocessing (redaction) and postprocessing (response capture).</li>
-        <li>Config audit log: Persist redaction configurations as YAML in version control for reproducibility.</li>
-      </ul>
-      <p>This architecture parallels zero-trust design, assuming each node is potentially untrusted and enforcing privacy at every hop.</p>
-
-      <h2>9. Compliance and Governance Alignment</h2>
-      <p>Effective PII detection is not just an engineering safeguard, it satisfies legal and ethical obligations under modern privacy frameworks.</p>
-      <p>Your stack should explicitly reference:</p>
-      <ul>
-        <li>GDPR Articles 5, 25 (Data minimization and Privacy by Design).</li>
-        <li>UK Data Protection Act (2018) Schedule 1.</li>
-        <li>SOC 2 Type II Security and Processing Integrity Controls.</li>
-        <li>ISO 27701 Extension for Privacy Information Management.</li>
-      </ul>
-      <p>By incorporating automated redaction, your organization meets the appropriate technical and organizational measures clause, proving that PII exposure is not accidental, but actively prevented.</p>
-
-      <h2>10. The Path Forward</h2>
-      <p>PII detection in LLM pipelines is no longer optional, it is structural. As AI workloads move into production, regulators, auditors, and enterprise clients expect verifiable privacy constraints.</p>
-      <p>Teams can already deploy end-to-end safeguards with:</p>
-      <ul>
-        <li>Local, deterministic redaction via <code>OpenRedaction.detect()</code>.</li>
-        <li>Gateway middleware via <code>@openredaction/express</code>.</li>
-        <li>Full visibility through your own audit and observability stack.</li>
-      </ul>
-      <p>Combined with OpenRedaction&apos;s regex-first precision, these tools form a privacy-first foundation for AI developers handling real-world data. Deep dive: <a href="/pii-redaction">PII redaction for AI systems</a>.</p>
-
-      <h2>Closing Thought</h2>
-      <p>In the era of generative computation, the true measure of responsible AI is not what models can learn, but what data they never see.</p>
-      <p>Detection and redaction are invisible victories: each scrubbed identifier represents one less compliance nightmare, one more proof of operational maturity. Redaction is not bureaucracy, it is architecture.</p>
-
-      <p style="margin-top: 2rem;">Questions or rollout help: <a href="/contact">contact</a> · <a href="/pricing">enterprise</a>.</p>
-
-      <div style="margin-top: 3rem; padding: 1.5rem; background-color: #111827; border: 1px solid #374151; border-radius: 0.5rem;">
-        <h3 style="margin-top: 0; margin-bottom: 1rem; font-size: 1.25rem; font-weight: 600; color: #fff;">Related</h3>
-        <ul style="margin-bottom: 0; padding-left: 1.5rem; list-style-type: disc; color: #d1d5db;">
-          <li style="margin-bottom: 0.5rem;"><a href="/pii-redaction" style="color: #fff; text-decoration: underline;">PII redaction for AI systems</a></li>
-          <li style="margin-bottom: 0.5rem;"><a href="/redact-pii-before-openai" style="color: #fff; text-decoration: underline;">Redact PII before OpenAI</a></li>
-          <li style="margin-bottom: 0.5rem;"><a href="/blog/pii-in-support-tickets" style="color: #fff; text-decoration: underline;">PII in support tickets &amp; chat</a></li>
-          <li style="margin-bottom: 0.5rem;"><a href="/blog/building-openredaction-developer-journey" style="color: #fff; text-decoration: underline;">How OpenRedaction is built</a></li>
-          <li style="margin-bottom: 0.5rem;"><a href="/playground" style="color: #fff; text-decoration: underline;">Playground</a></li>
-          <li style="margin-bottom: 0.5rem;"><a href="/nodejs-redaction" style="color: #fff; text-decoration: underline;">Node.js integration</a></li>
         </ul>
       </div>
     `,
@@ -439,8 +244,8 @@ async function safeCompletion(prompt) {
       <div style="margin-top: 3rem; padding: 1.5rem; background-color: #111827; border: 1px solid #374151; border-radius: 0.5rem;">
         <h3 style="margin-top: 0; margin-bottom: 1rem; font-size: 1.25rem; font-weight: 600; color: #fff;">Related</h3>
         <ul style="margin-bottom: 0; padding-left: 1.5rem; list-style-type: disc; color: #d1d5db;">
-          <li style="margin-bottom: 0.5rem;"><a href="/pii-redaction" style="color: #fff; text-decoration: underline;">PII redaction for AI systems</a></li>
-          <li style="margin-bottom: 0.5rem;"><a href="/blog/pii-detection-for-ai" style="color: #fff; text-decoration: underline;">PII detection for AI &amp; LLM pipelines</a></li>
+          <li style="margin-bottom: 0.5rem;"><a href="/pii-redaction" style="color: #fff; text-decoration: underline;">PII redaction</a></li>
+          <li style="margin-bottom: 0.5rem;"><a href="/pii-redaction" style="color: #fff; text-decoration: underline;">PII redaction</a></li>
           <li style="margin-bottom: 0.5rem;"><a href="/pii-detection" style="color: #fff; text-decoration: underline;">PII detection guide</a></li>
           <li style="margin-bottom: 0.5rem;"><a href="/playground" style="color: #fff; text-decoration: underline;">Try redaction in the playground</a></li>
           <li style="margin-bottom: 0.5rem;"><a href="/docs" style="color: #fff; text-decoration: underline;">Documentation</a></li>
@@ -517,91 +322,6 @@ export default async function BlogPost(props: {
     url: pageUrl,
   };
 
-  const aiFaqSchema =
-    params.slug === "pii-detection-for-ai"
-      ? {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          mainEntity: [
-            {
-              "@type": "Question",
-              name: "How do you detect and redact PII from LLM inputs before they reach the model?",
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: "Redact at the first hop — typically your API gateway or Express middleware — with local pattern-based detection before prompts leave your network. Optionally add NER inside a private VPC for unstructured names and entities, then merge spans in a single pass.",
-              },
-            },
-            {
-              "@type": "Question",
-              name: "How do you detect PII in LLM outputs?",
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: "Scan generated replies on the response path before storage or display. Models can echo user inputs or retrieved snippets; suppression filters prevent identifiers from resurfacing in completions, logs, or caches.",
-              },
-            },
-            {
-              "@type": "Question",
-              name: "Should PII redaction for AI use regex or machine learning?",
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: "Use pattern-first regex for structured identifiers (emails, phones, cards, IDs) because it is fast, local, and auditable. Add ML/NER only where narrative text needs it, preferably self-hosted, so detection does not create a new data residency risk.",
-              },
-            },
-          ],
-        }
-      : null;
-
-  // Question-form GSC queries for this URL had impressions with near-zero CTR;
-  // FAQ rich results improve snippet eligibility without changing page intent.
-  const supportFaqSchema =
-    params.slug === "pii-in-support-tickets"
-      ? {
-          "@context": "https://schema.org",
-          "@type": "FAQPage",
-          mainEntity: [
-            {
-              "@type": "Question",
-              name: "How do you handle PII in customer support tickets?",
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: "Assume every inbound channel will receive sensitive data. Collect the minimum needed to resolve the ticket, redact at ingest before indexing, mask identifiers in agent views, and keep short retention on unredacted transcripts.",
-              },
-            },
-            {
-              "@type": "Question",
-              name: "What PII commonly appears in support emails and chat?",
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: "Support threads often include names, emails, phones, account references, government or financial IDs, passwords and OTPs pasted to debug, and sometimes health or regulated context in attachments and screenshots.",
-              },
-            },
-            {
-              "@type": "Question",
-              name: "How should agents respond when a customer pastes a card number or password?",
-              acceptedAnswer: {
-                "@type": "Answer",
-                text: "Redact immediately (for cards, keep only the last four digits if needed), remove the value from searchable ticket history, log a brief remediation note, and route the user to a secure upload or verification path instead of asking for secrets in free text.",
-              },
-            },
-          ],
-        }
-      : null;
-
-  const pageFaqSchema = supportFaqSchema || aiFaqSchema;
-
-  // Process content - ensure links have proper styling
-  const processedContent = post.content
-    .replace(/<a href="([^"]+)">/g, (_match: string, href: string) => {
-      if (
-        href.startsWith("/") ||
-        href.startsWith("https://openredaction.com")
-      ) {
-        return `<a href="${href}" style="color: #fff; text-decoration: underline; hover:color: #d1d5db;">`;
-      }
-      return `<a href="${href}" target="_blank" rel="noopener noreferrer" style="color: #fff; text-decoration: underline;">`;
-    })
-    .trim();
-
   return (
     <div className="min-h-screen bg-black text-white">
       <Header />
@@ -613,16 +333,6 @@ export default async function BlogPost(props: {
           __html: JSON.stringify(blogPostingSchema),
         }}
       />
-      {pageFaqSchema ? (
-        <script
-          type="application/ld+json"
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: FAQ JSON-LD from static answers grounded in page content
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(pageFaqSchema),
-          }}
-        />
-      ) : null}
-
       <main className="pt-[148px] pb-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <Link

--- a/site/app/blog/page.tsx
+++ b/site/app/blog/page.tsx
@@ -11,16 +11,6 @@ import Header from "@/components/Header";
 const blogPosts = [
   {
     id: 1,
-    title:
-      "How to Detect and Redact PII in LLM Prompts Before They Reach the Model",
-    excerpt:
-      "Detect and redact PII in LLM inputs and outputs locally—before prompts hit vendors, logs, or RAG indexes. Pattern-first guardrails for AI pipelines.",
-    date: "2025-12-05",
-    category: "Guide",
-    slug: "pii-detection-for-ai",
-  },
-  {
-    id: 2,
     title: "How to Handle PII in Customer Support Tickets, Email & Chat",
     excerpt:
       "Is your helpdesk leaking customer PII? Practical redaction, retention, and agent workflows for Zendesk, Intercom, email, and chat.",
@@ -29,7 +19,7 @@ const blogPosts = [
     slug: "pii-in-support-tickets",
   },
   {
-    id: 3,
+    id: 2,
     title: "Building OpenRedaction: A Regex-First Open Source Story",
     excerpt:
       "How a small deterministic redaction experiment became a tested open-source library—patterns, trust, and what we learned shipping for privacy-minded developers.",

--- a/site/app/nodejs-redaction/page.tsx
+++ b/site/app/nodejs-redaction/page.tsx
@@ -49,7 +49,7 @@ export default function NodejsRedaction() {
                 href="/pii-redaction"
                 className="text-white underline underline-offset-4 hover:text-gray-200"
               >
-                PII redaction for AI systems
+                PII redaction
               </Link>
             </p>
           </div>
@@ -261,10 +261,10 @@ app.use(openredactionMiddleware({ autoRedact: true }));`}</code>
                 PII Detection Guide
               </Link>
               <Link
-                href="/blog/pii-detection-for-ai"
+                href="/pii-redaction"
                 className="text-gray-300 hover:text-white underline"
               >
-                PII Detection for AI
+                PII Redaction
               </Link>
               <Link
                 href="/gdpr-redaction"

--- a/site/app/pii-detection/page.tsx
+++ b/site/app/pii-detection/page.tsx
@@ -222,10 +222,10 @@ export default function PiiDetection() {
                 Installation Guide →
               </Link>
               <Link
-                href="/blog/pii-detection-for-ai"
+                href="/pii-redaction"
                 className="bg-gray-800 text-white px-6 py-3 rounded-md font-semibold hover:bg-gray-700 transition-colors border border-gray-700 text-center"
               >
-                PII &amp; LLMs →
+                PII Redaction →
               </Link>
             </div>
           </div>
@@ -252,10 +252,10 @@ export default function PiiDetection() {
                 HIPAA Redaction
               </Link>
               <Link
-                href="/blog/pii-detection-for-ai"
+                href="/pii-redaction"
                 className="text-gray-300 hover:text-white underline"
               >
-                PII Detection for AI
+                PII Redaction
               </Link>
             </div>
           </div>

--- a/site/app/pii-redaction/page.tsx
+++ b/site/app/pii-redaction/page.tsx
@@ -6,10 +6,9 @@ import Header from "@/components/Header";
 import { TrackedDocsGettingStartedLink } from "@/components/TrackedLinks";
 import { generatePageMetadata } from "@/lib/metadata";
 
-const pageTitle =
-  "PII Redaction for AI Systems: Detection, Logs, Citations & Node.js";
+const pageTitle = "PII Redaction";
 const pageDescription =
-  "What PII redaction is, where it belongs in AI pipelines, and how to implement it locally in Node.js—prompts, RAG, citations, logs, and OpenTelemetry.";
+  "PII redaction detects and masks personally identifiable information before text is stored, logged, embedded, or sent to an LLM. Local Node.js patterns for prompts, RAG, and logs.";
 
 export const metadata: Metadata = {
   ...generatePageMetadata({
@@ -19,8 +18,10 @@ export const metadata: Metadata = {
   }),
   keywords: [
     "PII redaction",
-    "PII redaction AI",
+    "what is PII redaction",
+    "redact PII",
     "personally identifiable information redaction",
+    "PII redaction AI",
     "redact PII before LLM",
     "PII redaction Node.js",
     "AI citation redaction",
@@ -33,13 +34,15 @@ export const metadata: Metadata = {
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://openredaction.com";
 
 const toc = [
-  { id: "what-is-pii-redaction", label: "What PII redaction really is" },
-  { id: "why-pii-redaction", label: "Why it is critical for AI systems" },
+  { id: "what-is-pii-redaction", label: "What is PII redaction?" },
+  { id: "why-pii-redaction", label: "Why it matters" },
   { id: "entities", label: "Core PII entities" },
   { id: "redaction-vs-anonymization", label: "Redaction vs anonymization" },
+  { id: "pattern-vs-ml", label: "Pattern-first vs ML detection" },
   { id: "defense-in-depth", label: "Defense-in-depth strategy" },
   { id: "how-to-implement", label: "How to implement with OpenRedaction" },
-  { id: "placement", label: "Where to redact in AI pipelines" },
+  { id: "placement", label: "Where to redact" },
+  { id: "redaction-styles", label: "Redaction styles" },
   { id: "telemetry", label: "Logs, traces, and telemetry" },
   { id: "ai-citations", label: "Redaction for AI citations" },
   { id: "governance", label: "Policies and governance" },
@@ -52,6 +55,17 @@ const faqItems = [
     question: "What is PII redaction?",
     answer:
       "PII redaction is the practice of detecting and masking personally identifiable information before text is stored, logged, embedded, or sent to an LLM or third-party API. Typical targets include emails, phone numbers, national IDs, and other identifiers that can single someone out.",
+  },
+  {
+    question:
+      "How do you detect and redact PII from LLM inputs before they reach the model?",
+    answer:
+      "Redact at the first hop—typically your API gateway or Express middleware—with local pattern-based detection before prompts leave your network. Optionally add NER inside a private VPC for unstructured names and entities, then merge spans in a single pass.",
+  },
+  {
+    question: "How do you detect PII in LLM outputs?",
+    answer:
+      "Scan generated replies on the response path before storage or display. Models can echo user inputs or retrieved snippets; suppression filters prevent identifiers from resurfacing in completions, logs, or caches.",
   },
   {
     question: "Is PII redaction the same as anonymization?",
@@ -126,7 +140,8 @@ export default function PiiRedactionPage() {
     headline: pageTitle,
     description: pageDescription,
     url: `${siteUrl}/pii-redaction`,
-    dateModified: "2026-08-05",
+    datePublished: "2025-12-05",
+    dateModified: "2026-08-07",
     author: {
       "@type": "Organization",
       name: "OpenRedaction",
@@ -205,15 +220,14 @@ export default function PiiRedactionPage() {
               Implementation guide
             </p>
             <h1 className="mt-4 text-4xl sm:text-5xl lg:text-6xl font-semibold tracking-tight text-balance">
-              PII Redaction for AI Systems
+              PII Redaction
             </h1>
             <p className="mt-5 text-lg text-gray-300 leading-relaxed">
-              Protecting personally identifiable information is a core
-              requirement for any AI system that handles real-world data—
-              especially when prompts, logs, traces, embeddings, and citations
-              can unintentionally leak who the data is about. This guide covers
-              how to design, implement, and operate PII redaction across modern
-              AI pipelines.
+              PII redaction is how you stop personally identifiable information
+              from reaching models, logs, vector stores, and citations. This
+              guide explains what it is, where it belongs in AI pipelines, and
+              how to implement it locally in Node.js before prompts ever leave
+              your process.
             </p>
             <div className="mt-6 flex flex-wrap items-center gap-3 text-sm text-gray-400">
               <TrackedDocsGettingStartedLink
@@ -263,15 +277,21 @@ export default function PiiRedactionPage() {
           <div className="mt-14 space-y-14 text-gray-300 leading-relaxed">
             <section id="what-is-pii-redaction" className="scroll-mt-28">
               <h2 className="text-2xl sm:text-3xl font-semibold text-white">
-                What PII redaction really is
+                What is PII redaction?
               </h2>
               <p className="mt-4">
-                PII redaction is the practice of detecting and masking
-                information that can directly or indirectly identify an
-                individual before that data is stored, processed, or exposed
-                downstream. In AI systems, that includes prompts, model outputs,
-                logs, traces, embeddings, analytics, and any citation that
-                points back to user data.
+                <strong className="text-white">PII redaction</strong> is the
+                practice of detecting and masking information that can directly
+                or indirectly identify an individual before that data is stored,
+                processed, or exposed downstream. In AI systems, that includes
+                prompts, model outputs, logs, traces, embeddings, analytics, and
+                any citation that points back to user data.
+              </p>
+              <p className="mt-4">
+                Unlike a one-off filter, effective PII redaction is a control
+                plane: the same entity taxonomy and masking policy applied at
+                every trust boundary so a single prompt cannot fan out into
+                vendor APIs, RAG indexes, and observability tools unchanged.
               </p>
               <p className="mt-4">PII broadly covers two categories:</p>
               <ul className="mt-4 list-disc space-y-2 pl-5">
@@ -290,13 +310,13 @@ export default function PiiRedactionPage() {
               </ul>
               <p className="mt-4">
                 What matters most is not only what counts as PII, but{" "}
-                <em>where</em> it can appear across your AI stack. For a
-                detection-focused treatment of prompts and RAG surfaces, see{" "}
+                <em>where</em> it can appear. For detection primitives and
+                pattern coverage, see the{" "}
                 <Link
-                  href="/blog/pii-detection-for-ai"
+                  href="/pii-detection"
                   className="text-white underline underline-offset-4"
                 >
-                  PII detection for AI workflows
+                  PII detection overview
                 </Link>
                 .
               </p>
@@ -304,7 +324,7 @@ export default function PiiRedactionPage() {
 
             <section id="why-pii-redaction" className="scroll-mt-28">
               <h2 className="text-2xl sm:text-3xl font-semibold text-white">
-                Why PII redaction is critical for AI systems
+                Why PII redaction matters
               </h2>
               <p className="mt-4">
                 AI systems amplify traditional privacy risks because they copy,
@@ -312,11 +332,34 @@ export default function PiiRedactionPage() {
                 redaction, a single prompt can end up in model vendor logs,
                 vector stores, observability platforms, and audit trails.
               </p>
+              <h3 className="mt-6 text-lg font-medium text-white">
+                Common injection points
+              </h3>
               <ul className="mt-4 list-disc space-y-2 pl-5">
                 <li>
+                  <strong className="text-white">Inbound streams:</strong> user
+                  prompts, uploads, and pasted exports (CSV, DOCX, CRM
+                  snapshots)
+                </li>
+                <li>
+                  <strong className="text-white">Processing layers:</strong>{" "}
+                  system logs, traces, APM instrumentation, and replay tools
+                </li>
+                <li>
+                  <strong className="text-white">Storage:</strong> vector
+                  databases, embeddings, RAG indexes, and training sets
+                </li>
+                <li>
+                  <strong className="text-white">Outbound channels:</strong>{" "}
+                  model responses that echo prompts, retrieved snippets, or
+                  internal context
+                </li>
+              </ul>
+              <ul className="mt-6 list-disc space-y-2 pl-5">
+                <li>
                   <strong className="text-white">Regulatory compliance:</strong>{" "}
-                  GDPR, CCPA, HIPAA, and sector rules increasingly expect
-                  proactive controls on personal data (see{" "}
+                  GDPR, CCPA, HIPAA, and sector rules expect proactive controls
+                  on personal data (see{" "}
                   <Link
                     href="/gdpr-redaction"
                     className="text-white underline underline-offset-4"
@@ -343,10 +386,6 @@ export default function PiiRedactionPage() {
                   controls are concrete and inspectable
                 </li>
               </ul>
-              <p className="mt-4">
-                For AI citations specifically, redaction keeps references
-                informative without leaking who the underlying data is about.
-              </p>
             </section>
 
             <section id="entities" className="scroll-mt-28">
@@ -447,6 +486,45 @@ export default function PiiRedactionPage() {
                 citations should not leak real identifiers, but privileged
                 services may still need to resolve a placeholder back to a
                 record.
+              </p>
+            </section>
+
+            <section id="pattern-vs-ml" className="scroll-mt-28">
+              <h2 className="text-2xl sm:text-3xl font-semibold text-white">
+                Pattern-first vs machine learning detection
+              </h2>
+              <p className="mt-4">
+                There are two dominant paradigms for detecting sensitive text:
+                pattern-first (regex-based) and ML/NLP-based. Production systems
+                usually combine both—starting with the layer you can deploy
+                everywhere without shipping raw text to another processor.
+              </p>
+              <h3 className="mt-6 text-lg font-medium text-white">
+                Pattern-first (regex / rule-based)
+              </h3>
+              <p className="mt-3">
+                Regex-driven detectors catch structured identifiers—emails,
+                phone numbers, credit cards, postal codes, and national IDs—
+                with deterministic precision. They are fast, local, and
+                auditable, which makes them the right first hop before content
+                reaches an LLM API.
+              </p>
+              <h3 className="mt-6 text-lg font-medium text-white">
+                ML / named entity recognition (NER)
+              </h3>
+              <p className="mt-3">
+                NER expands coverage to unstructured narrative—names,
+                organisations, and contextual references that rigid patterns
+                miss. Trade-offs are latency, cost, and data residency if
+                inference runs outside your boundary.
+              </p>
+              <p className="mt-4">
+                <strong className="text-white">Optimal architecture:</strong>{" "}
+                run high-precision pattern redaction locally, optionally apply
+                NER inside a private VPC, then merge spans in a single pass.
+                OpenRedaction focuses on the deterministic layer you can ship in
+                every Node process; optional local NER sits behind the same
+                boundary when you need free-text name coverage.
               </p>
             </section>
 
@@ -666,10 +744,11 @@ const restored = redactor.restore(redactedCitation, map);`}
           <div className="mt-14 space-y-14 text-gray-300 leading-relaxed">
             <section id="placement" className="scroll-mt-28">
               <h2 className="text-2xl sm:text-3xl font-semibold text-white">
-                Placement: where to redact in AI pipelines
+                Where to redact in AI pipelines
               </h2>
               <p className="mt-4">
-                Placement is as important as detection quality.
+                Placement is as important as detection quality. Treat every hop
+                where text leaves a trust boundary as a redaction checkpoint.
               </p>
               <ul className="mt-4 list-disc space-y-2 pl-5">
                 <li>
@@ -682,13 +761,18 @@ const restored = redactor.restore(redactedCitation, map);`}
                   <strong className="text-white">
                     Application / RAG layer:
                   </strong>{" "}
-                  integrate into middleware and chunking so embeddings never
-                  store raw identifiers
+                  redact early in chunking so embeddings never store raw
+                  identifiers
                 </li>
                 <li>
                   <strong className="text-white">Observability layer:</strong>{" "}
                   use collectors and span processors to scrub attributes before
                   export
+                </li>
+                <li>
+                  <strong className="text-white">Response path:</strong> scan
+                  generated replies before storage or display—models can echo
+                  user inputs or retrieved snippets
                 </li>
                 <li>
                   <strong className="text-white">Storage and analytics:</strong>{" "}
@@ -698,6 +782,43 @@ const restored = redactor.restore(redactedCitation, map);`}
               <p className="mt-4">
                 In practice, many teams combine a model gateway with
                 collector-level redaction for logs and traces.
+              </p>
+            </section>
+
+            <section id="redaction-styles" className="scroll-mt-28">
+              <h2 className="text-2xl sm:text-3xl font-semibold text-white">
+                Redaction styles and consistency
+              </h2>
+              <p className="mt-4">
+                How you represent scrubbed values matters as much as catching
+                them. Pick a style, document it, and apply it globally—auditors
+                prefer a stable schema over clever one-offs.
+              </p>
+              <ul className="mt-4 list-disc space-y-2 pl-5">
+                <li>
+                  <strong className="text-white">Full placeholders</strong>{" "}
+                  (e.g. <code className="text-green-400">[EMAIL_9619]</code>)
+                  for external model traffic and vendor APIs
+                </li>
+                <li>
+                  <strong className="text-white">Partial masking</strong> (e.g.{" "}
+                  <code className="text-green-400">jo***@domain.com</code>) only
+                  for internal dashboards or controlled analytics
+                </li>
+                <li>
+                  <strong className="text-white">Token replace</strong> when a
+                  privileged service must restore the original later
+                </li>
+              </ul>
+              <p className="mt-4">
+                OpenRedaction supports{" "}
+                <code className="text-gray-200">placeholder</code>,{" "}
+                <code className="text-gray-200">mask-middle</code>,{" "}
+                <code className="text-gray-200">mask-all</code>,{" "}
+                <code className="text-gray-200">format-preserving</code>, and{" "}
+                <code className="text-gray-200">token-replace</code> modes so
+                you can use irreversible placeholders for vendors and softer
+                masking for internal tools.
               </p>
             </section>
 
@@ -831,8 +952,9 @@ service:
                 Evaluation: precision, recall, and quality
               </h2>
               <p className="mt-4">
-                Redaction pipelines need continuous evaluation or they rot
-                quietly.
+                Privacy assurance is not theoretical—it needs continuous,
+                automated proof. Treat redaction checks as part of CI/CD, not a
+                post-incident cleanup.
               </p>
               <ul className="mt-4 list-disc space-y-2 pl-5">
                 <li>
@@ -840,15 +962,20 @@ service:
                   sensitive reaches models or logs
                 </li>
                 <li>
+                  Inject canary values (e.g. a unique test email) into prompts
+                  and verify they never appear in logs, embeddings, or LLM
+                  responses
+                </li>
+                <li>
                   Prioritise recall for high-risk entities even when that means
                   some over-redaction
                 </li>
                 <li>
-                  Tune confidence thresholds and human-review queues per entity
-                  type
+                  Track latency budgets (for example under 50ms per prompt)—if
+                  redaction slows the path, teams will bypass it under pressure
                 </li>
                 <li>
-                  Periodically scan prompts, logs, and citation stores for
+                  Periodically scan vector stores and citation indexes for
                   regressions
                 </li>
               </ul>
@@ -930,14 +1057,6 @@ service:
                   className="text-white underline underline-offset-4"
                 >
                   How to redact PII before OpenAI
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/blog/pii-detection-for-ai"
-                  className="text-white underline underline-offset-4"
-                >
-                  Detect &amp; redact PII in LLM prompts and outputs
                 </Link>
               </li>
               <li>

--- a/site/app/redact-pii-before-openai/page.tsx
+++ b/site/app/redact-pii-before-openai/page.tsx
@@ -92,7 +92,7 @@ await openai.chat.completions.create({
                   href="/pii-redaction"
                   className="text-white underline underline-offset-4"
                 >
-                  PII redaction for AI systems
+                  PII redaction
                 </Link>{" "}
                 guide.
               </p>

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -66,6 +66,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
     lastModified: new Date(),
     changeFrequency:
       route === "" ? "daily" : route.startsWith("/blog") ? "weekly" : "monthly",
-    priority: route === "" ? 1 : route.startsWith("/blog") ? 0.7 : 0.8,
+    priority:
+      route === ""
+        ? 1
+        : route === "/pii-redaction"
+          ? 0.9
+          : route.startsWith("/blog")
+            ? 0.7
+            : 0.8,
   }));
 }

--- a/site/docs/pages/tutorials.mdx
+++ b/site/docs/pages/tutorials.mdx
@@ -244,5 +244,5 @@ const batchResult = await processor.process(documents.map((d) => d.text));
 - [Getting started](/getting-started)
 - [Examples](/examples)
 - [Node.js redaction](https://openredaction.com/nodejs-redaction)
-- [PII redaction for AI systems](https://openredaction.com/pii-redaction)
+- [PII redaction](https://openredaction.com/pii-redaction)
 - [Self-hosting](/self-hosting)

--- a/site/lib/blogPosts.ts
+++ b/site/lib/blogPosts.ts
@@ -8,15 +8,6 @@ export const blogPosts: { [key: string]: any } = {
       "How a small deterministic redaction experiment became a tested open-source library—patterns, trust, and what we learned shipping for privacy-minded developers.",
     slug: "building-openredaction-developer-journey",
   },
-  "pii-detection-for-ai": {
-    title:
-      "How to Detect and Redact PII in LLM Prompts Before They Reach the Model",
-    date: "2025-12-05",
-    category: "Guide",
-    excerpt:
-      "Detect and redact PII in LLM inputs and outputs locally—before prompts hit vendors, logs, or RAG indexes. Pattern-first guardrails for AI pipelines.",
-    slug: "pii-detection-for-ai",
-  },
   "pii-in-support-tickets": {
     title: "How to Handle PII in Customer Support Tickets, Email & Chat",
     date: "2025-12-11",

--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -4,7 +4,8 @@ import corePkg from "../packages/core/package.json";
 
 /** Soft-404 / retired blog URLs → nearest live guide (not a dump to /blog). */
 const removedBlogRedirects: Record<string, string> = {
-  "understanding-pii-detection": "/blog/pii-detection-for-ai",
+  "understanding-pii-detection": "/pii-redaction",
+  "pii-detection-for-ai": "/pii-redaction",
   "10-common-pii-redaction-mistakes": "/pii-redaction",
   "7-pii-redaction-best-practices": "/pii-redaction",
   "data-redaction-vs-masking": "/pii-redaction",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Promote the LLM PII blog into the canonical `/pii-redaction` root article with an exact-match title, and retire the competing blog URL so ranking signals consolidate for “PII Redaction”.

## Changes

- Retitle `/pii-redaction` to **PII Redaction** (metadata, H1, JSON-LD) and tighten the meta description for the head term
- Absorb unique blog sections (injection points, pattern-first vs ML, redaction styles, canary/audit evaluation, LLM I/O FAQs)
- 301 `/blog/pii-detection-for-ai` and `understanding-pii-detection` → `/pii-redaction`; remove the post from the blog index/sitemap sources
- Retarget internal links from detection/Node.js/related guides to the root URL; bump `/pii-redaction` sitemap priority to 0.9

## Testing

- [x] `bun run lint` / pre-push lint
- [x] `bun run typecheck` / pre-push typecheck
- [ ] Manual: `/pii-redaction` title/H1 is **PII Redaction**
- [ ] Manual: `/blog/pii-detection-for-ai` permanently redirects to `/pii-redaction`
- [ ] Manual: blog index no longer lists the retired post

## Checklist

- [ ] Added/updated tests
- [x] Updated documentation (tutorials link copy)
- [x] Checked for breaking changes and documented migration steps if needed (permanent redirect preserves old blog URL)
- [ ] Linked any relevant issues

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fde0e-9874-7618-97c2-45d9fed7faa0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fde0e-9874-7618-97c2-45d9fed7faa0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

