### PR TITLE
Add PII Redaction to primary header navigation

### DIFF
--- a/site/components/Header.tsx
+++ b/site/components/Header.tsx
@@ -52,6 +52,13 @@ export default function Header() {
                 Playground
               </Link>
               <Link
+                href="/pii-redaction"
+                className="text-gray-300 hover:text-white transition-colors"
+                onClick={() => analytics.navClick("/pii-redaction", "header")}
+              >
+                PII Redaction
+              </Link>
+              <Link
                 href="/pricing"
                 className="text-gray-300 hover:text-white transition-colors"
                 onClick={() => analytics.navClick("/pricing", "header")}
@@ -238,6 +245,16 @@ export default function Header() {
               }}
             >
               Playground
+            </Link>
+            <Link
+              href="/pii-redaction"
+              className="block text-gray-300 hover:text-white transition-colors"
+              onClick={() => {
+                setMobileMenuOpen(false);
+                analytics.navClick("/pii-redaction", "mobile");
+              }}
+            >
+              PII Redaction
             </Link>
             <Link
               href="/pricing"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Surface the canonical `/pii-redaction` guide in the main top nav so the SEO landing page is also a first-class site destination.

## Changes

- Add **PII Redaction** link to desktop header nav (between Playground and Enterprise)
- Add the same link to the mobile menu

## Testing

- [x] Pre-push lint/typecheck
- [ ] Manual: desktop header shows **PII Redaction** and routes to `/pii-redaction`
- [ ] Manual: mobile menu shows **PII Redaction** and routes to `/pii-redaction`

## Checklist

- [ ] Added/updated tests
- [ ] Updated documentation
- [x] Checked for breaking changes and documented migration steps if needed
- [ ] Linked any relevant issues

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fde0e-9874-7618-97c2-45d9fed7faa0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fde0e-9874-7618-97c2-45d9fed7faa0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

