### PR TITLE
ci: skip husky on Dependabot lockfile push

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -29,4 +29,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add bun.lock
-          git diff --staged --quiet || (git commit -m "chore: update bun.lock" && git push)
+          # Skip husky: CI checkout has no workspace package builds, so pre-push typecheck fails.
+          git diff --staged --quiet || (git commit -m "chore: update bun.lock" && HUSKY=0 git push)


### PR DESCRIPTION
## Summary
- Dependabot site PRs fail `bun install --frozen-lockfile` because the lockfile updater cannot push: husky pre-push runs typecheck without built packages
- Set `HUSKY=0` on that workflow push so regenerated `bun.lock` commits land

## Test plan
- [ ] Merge, then re-run or recreate a site Dependabot PR and confirm `update-lockfile` commits

Made with [Cursor](https://cursor.com)